### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ implementation 'com.apple.itunes.storekit:app-store-server-library:0.1.1'
 ```xml
 <dependency>
     <groupId>com.apple.itunes.storekit</groupId>
-    <artifcatId>app-store-server-library</artifcatId>
+    <artifactId>app-store-server-library</artifactId>
     <version>0.1.1</version>
 </dependency>
 ```


### PR DESCRIPTION
Change typo in Maven dependency: tag `artifcatId` changed to `artifactId`