### PR TITLE
Use placeholder URL when LOCAL_TESTING environment option is provided

### DIFF
--- a/src/main/java/com/apple/itunes/storekit/client/AppStoreServerAPIClient.java
+++ b/src/main/java/com/apple/itunes/storekit/client/AppStoreServerAPIClient.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 public class AppStoreServerAPIClient {
     private static final String PRODUCTION_URL = "https://api.storekit.itunes.apple.com";
     private static final String SANDBOX_URL = "https://api.storekit-sandbox.itunes.apple.com";
+    private static final String LOCAL_TESTING_URL = "https://local-testing-base-url";
     private static final String USER_AGENT = "app-store-server-library/java/2.0.0";
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
@@ -64,7 +65,22 @@ public class AppStoreServerAPIClient {
         this.bearerTokenAuthenticator = new BearerTokenAuthenticator(signingKey, keyId, issuerId, bundleId);
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         this.httpClient = builder.build();
-        this.urlBase = HttpUrl.parse(environment.equals(Environment.SANDBOX) ? SANDBOX_URL : PRODUCTION_URL);
+        switch (environment) {
+            case XCODE:
+                throw new IllegalArgumentException("Xcode is not a supported environment for an AppStoreServerAPIClient");
+            case PRODUCTION:
+                this.urlBase = HttpUrl.parse(PRODUCTION_URL);
+                break;
+            case LOCAL_TESTING:
+                this.urlBase = HttpUrl.parse(LOCAL_TESTING_URL);
+                break;
+            case SANDBOX:
+                this.urlBase = HttpUrl.parse(SANDBOX_URL);
+                break;
+            default:
+                // This switch statement is exhaustive
+                throw new IllegalStateException();
+        }
         this.objectMapper = new ObjectMapper();
         objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
                 .withFieldVisibility(JsonAutoDetect.Visibility.ANY)

--- a/src/main/java/com/apple/itunes/storekit/model/Environment.java
+++ b/src/main/java/com/apple/itunes/storekit/model/Environment.java
@@ -14,6 +14,7 @@ public enum Environment {
     SANDBOX("Sandbox"),
     PRODUCTION("Production"),
     XCODE("Xcode"),
+    // Used for unit testing
     LOCAL_TESTING("LocalTesting");
 
     private final String value;

--- a/src/test/java/com/apple/itunes/storekit/client/AppStoreServerAPIClientTest.java
+++ b/src/test/java/com/apple/itunes/storekit/client/AppStoreServerAPIClientTest.java
@@ -562,6 +562,17 @@ public class AppStoreServerAPIClientTest {
         Assertions.fail();
     }
 
+    @Test
+    public void testXcodeEnvironmentNotSupportedError() throws IOException {
+        try (InputStream key = this.getClass().getClassLoader().getResourceAsStream("certs/testSigningKey.p8")) {
+            new AppStoreServerAPIClient(new String(key.readAllBytes()), "keyId", "issuerId", "com.example", Environment.XCODE);
+        } catch (IllegalArgumentException e) {
+            Assertions.assertEquals("Xcode is not a supported environment for an AppStoreServerAPIClient", e.getMessage());
+            return;
+        }
+        Assertions.fail();
+    }
+
     public AppStoreServerAPIClient getClientWithBody(String path, Consumer<Request> requestVerifier) throws IOException {
         String body = TestingUtility.readFile(path);
         return getAppStoreServerAPIClient(body, requestVerifier);


### PR DESCRIPTION
    Block creation of an AppStoreServerAPIClient with environment XCODE