### PR TITLE
Update JUnit to JUnit 5.12, which requires the launcher as a runtime …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,8 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.5.0'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.80'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.12.0'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.mockito:mockito-core:5.16.0'
 }
 


### PR DESCRIPTION
…dependency