### PR TITLE
Add support for Set App Account Token endpoint

### DIFF
--- a/src/main/java/com/apple/itunes/storekit/client/APIError.java
+++ b/src/main/java/com/apple/itunes/storekit/client/APIError.java
@@ -301,6 +301,27 @@ public enum APIError {
     APP_TRANSACTION_ID_NOT_SUPPORTED_ERROR(4000048L),
 
     /**
+     * An error that indicates the app account token value is not a valid UUID.
+     *
+     * @see <a href="https://developer.apple.com/documentation/appstoreserverapi/invalidappaccounttokenuuiderror">InvalidAppAccountTokenUUIDError</a>
+     */
+    INVALID_APP_ACCOUNT_TOKEN_UUID_ERROR(4000183L),
+
+    /**
+     * An error that indicates the transaction is for a product the customer obtains through Family Sharing, which the endpoint doesn’t support.
+     *
+     * @see <a href="https://developer.apple.com/documentation/appstoreserverapi/familytransactionnotsupportederror">FamilyTransactionNotSupportedError</a>
+     */
+    FAMILY_TRANSACTION_NOT_SUPPORTED_ERROR(4000185L),
+
+    /**
+     * An error that indicates the endpoint expects an original transaction identifier.
+     *
+     * @see <a href="https://developer.apple.com/documentation/appstoreserverapi/transactionidisnotoriginaltransactioniderror">TransactionIdIsNotOriginalTransactionIdError</a>
+     */
+    TRANSACTION_ID_IS_NOT_ORIGINAL_TRANSACTION_ID_ERROR(4000187L),
+
+    /**
      * An error that indicates the subscription doesn't qualify for a renewal-date extension due to its subscription state.
      *
      * @see <a href="https://developer.apple.com/documentation/appstoreserverapi/subscriptionextensionineligibleerror">SubscriptionExtensionIneligibleError</a>

--- a/src/main/java/com/apple/itunes/storekit/client/BaseAppStoreServerAPIClient.java
+++ b/src/main/java/com/apple/itunes/storekit/client/BaseAppStoreServerAPIClient.java
@@ -21,6 +21,7 @@ import com.apple.itunes.storekit.model.Status;
 import com.apple.itunes.storekit.model.StatusResponse;
 import com.apple.itunes.storekit.model.TransactionHistoryRequest;
 import com.apple.itunes.storekit.model.TransactionInfoResponse;
+import com.apple.itunes.storekit.model.UpdateAppAccountTokenRequest;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -357,6 +358,20 @@ public abstract class BaseAppStoreServerAPIClient {
      */
     public void sendConsumptionData(String transactionId, ConsumptionRequest consumptionRequest) throws APIException, IOException {
         makeHttpCall("/inApps/v1/transactions/consumption/" + transactionId, "PUT", Map.of(), consumptionRequest, Void.class);
+    }
+
+
+    /**
+     * Sets the app account token value for a purchase the customer makes outside your app, or updates its value in an existing transaction.
+     *
+     * @param originalTransactionId The original transaction identifier of the transaction to receive the app account token update.
+     * @param updateAppAccountTokenRequest The request body that contains a valid app account token value.
+     * @throws APIException If a response was returned indicating the request could not be processed.
+     * @throws IOException  If an exception was thrown while making the request.
+     * @see <a href="https://developer.apple.com/documentation/appstoreserverapi/set-app-account-token">Set App Account Token</a>
+     */
+    public void setAppAccountToken(String originalTransactionId, UpdateAppAccountTokenRequest updateAppAccountTokenRequest) throws APIException, IOException {
+        makeHttpCall("/inApps/v1/transactions/" + originalTransactionId + "/appAccountToken", "PUT", Map.of(), updateAppAccountTokenRequest, Void.class);
     }
 
     protected interface HttpResponseInterface extends Closeable {

--- a/src/main/java/com/apple/itunes/storekit/model/UpdateAppAccountTokenRequest.java
+++ b/src/main/java/com/apple/itunes/storekit/model/UpdateAppAccountTokenRequest.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+package com.apple.itunes.storekit.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * The request body that contains an app account token value.
+ *
+ * @see <a href="https://developer.apple.com/documentation/appstoreserverapi/updateappaccounttokenrequest">UpdateAppAccountTokenRequest</a>
+ **/
+public class UpdateAppAccountTokenRequest {
+    private static final String SERIALIZED_NAME_APP_ACCOUNT_TOKEN = "appAccountToken";
+    @JsonProperty(value = SERIALIZED_NAME_APP_ACCOUNT_TOKEN, required = true)
+    private UUID appAccountToken;
+
+    private UpdateAppAccountTokenRequest() {
+    }
+
+    public UpdateAppAccountTokenRequest(UUID appAccountToken) {
+        Objects.requireNonNull(appAccountToken);
+        this.appAccountToken = appAccountToken;
+    }
+
+    public UpdateAppAccountTokenRequest appAccountToken(UUID appAccountToken) {
+        Objects.requireNonNull(appAccountToken);
+        this.appAccountToken = appAccountToken;
+        return this;
+    }
+
+    /**
+     * The UUID that an app optionally generates to map a customer’s in-app purchase with its resulting App Store transaction.
+     *
+     * @return appAccountToken
+     * @see <a href="https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken">appAccountToken</a>
+     **/
+    public UUID getAppAccountToken() {
+        return appAccountToken;
+    }
+
+    public void setAppAccountToken(UUID appAccountToken) {
+        Objects.requireNonNull(appAccountToken);
+        this.appAccountToken = appAccountToken;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof UpdateAppAccountTokenRequest)) return false;
+        UpdateAppAccountTokenRequest that = (UpdateAppAccountTokenRequest) o;
+        return Objects.equals(getAppAccountToken(), that.getAppAccountToken());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getAppAccountToken());
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateAppAccountTokenRequest{" +
+                "appAccountToken=" + appAccountToken +
+                '}';
+    }
+}

--- a/src/test/resources/models/familyTransactionNotSupportedError.json
+++ b/src/test/resources/models/familyTransactionNotSupportedError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000185,
+  "errorMessage": "Invalid request. Family Sharing transactions aren't supported by this endpoint."
+}

--- a/src/test/resources/models/transactionIdNotOriginalTransactionId.json
+++ b/src/test/resources/models/transactionIdNotOriginalTransactionId.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000187,
+  "errorMessage": "Invalid request. The transaction ID provided is not an original transaction ID."
+}


### PR DESCRIPTION
Description: Adding implementation for calling the Set App Account Token S2S using App Store Server Library.

For more info, please visit our developer documentation: https://developer.apple.com/documentation/appstoreserverapi/set-app-account-token