### PR TITLE
Update Gradle wrapper validation action

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -8,4 +8,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: gradle/wrapper-validation-action@v3.5.0
+      - uses: gradle/actions/wrapper-validation@v5


### PR DESCRIPTION
From the action's repository readme:

>As of v3 this action has been superceded by gradle/actions/wrapper-validation. Any workflow that uses gradle/wrapper-validation-action@v3 will transparently delegate to gradle/actions/wrapper-validation@v3.

But we should update to the latest version available.