### PR TITLE
Decode JWS payloads as UTF-8 instead of the JVM default charset

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,13 @@ java {
     withJavadocJar()
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
 javadoc {
     source = sourceSets.main.allJava
+    options.encoding = 'UTF-8'
 }
 
 signing {

--- a/src/main/java/com/apple/itunes/storekit/verification/SignedDataVerifier.java
+++ b/src/main/java/com/apple/itunes/storekit/verification/SignedDataVerifier.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 import java.security.interfaces.ECPublicKey;
 import java.util.Base64;
@@ -218,7 +219,7 @@ public class SignedDataVerifier {
     }
 
     protected <T extends DecodedSignedData> T parseJWTPayload(Class<T> clazz, DecodedJWT jwt) throws VerificationException {
-        String payload = new String(Base64.getUrlDecoder().decode(jwt.getPayload()));
+        String payload = new String(Base64.getUrlDecoder().decode(jwt.getPayload()), StandardCharsets.UTF_8);
         try {
             return objectMapper.readValue(payload, clazz);
         } catch (JsonProcessingException e) {

--- a/src/test/java/com/apple/itunes/storekit/verification/SignedDataVerifierTest.java
+++ b/src/test/java/com/apple/itunes/storekit/verification/SignedDataVerifierTest.java
@@ -2,16 +2,19 @@
 
 package com.apple.itunes.storekit.verification;
 
+import com.apple.itunes.storekit.model.AdvancedCommerceTransactionInfo;
 import com.apple.itunes.storekit.model.Environment;
 import com.apple.itunes.storekit.model.JWSRenewalInfoDecodedPayload;
 import com.apple.itunes.storekit.model.JWSTransactionDecodedPayload;
 import com.apple.itunes.storekit.model.NotificationTypeV2;
 import com.apple.itunes.storekit.model.ResponseBodyV2DecodedPayload;
+import com.apple.itunes.storekit.util.SignedDataCreator;
 import com.apple.itunes.storekit.util.TestingUtility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 
 public class SignedDataVerifierTest {
 
@@ -83,5 +86,23 @@ public class SignedDataVerifierTest {
         SignedDataVerifier verifier = TestingUtility.getSignedPayloadVerifier();
         VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeNotification("a.b.c"));
         Assertions.assertEquals(VerificationStatus.VERIFICATION_FAILURE, exception.getStatus());
+    }
+
+    /**
+     * The payload of a JWS is always UTF-8 encoded, so decoding it must not depend on the default charset of the JVM.
+     * The expected values below are written as escape sequences so that this test does not depend on the encoding
+     * used to compile it either.
+     */
+    @Test
+    public void testNonAsciiDataDecodingIsIndependentOfTheDefaultCharset() throws VerificationException, IOException, NoSuchAlgorithmException {
+        String signedTransaction = SignedDataCreator.createSignedDataFromJson("models/signedTransactionWithNonAsciiData.json");
+
+        JWSTransactionDecodedPayload transaction = TestingUtility.getSignedPayloadVerifier().verifyAndDecodeTransaction(signedTransaction);
+
+        AdvancedCommerceTransactionInfo advancedCommerceInfo = transaction.getAdvancedCommerceInfo();
+        Assertions.assertEquals("Abonnement Caf\u00e9 \u2014 5,99 \u20ac par mois", advancedCommerceInfo.getDescriptors().getDescription());
+        Assertions.assertEquals("Caf\u00e9 Premium", advancedCommerceInfo.getDescriptors().getDisplayName());
+        Assertions.assertEquals("\u30d7\u30ec\u30df\u30a2\u30e0\u6a5f\u80fd", advancedCommerceInfo.getItems().get(0).getDescription());
+        Assertions.assertEquals("\u30d7\u30ec\u30df\u30a2\u30e0", advancedCommerceInfo.getItems().get(0).getDisplayName());
     }
 }

--- a/src/test/resources/models/signedTransactionWithNonAsciiData.json
+++ b/src/test/resources/models/signedTransactionWithNonAsciiData.json
@@ -1,0 +1,23 @@
+{
+  "transactionId":"23456",
+  "originalTransactionId":"12345",
+  "bundleId":"com.example",
+  "productId":"com.example.product",
+  "purchaseDate":1698148900000,
+  "signedDate":1698148900000,
+  "environment":"LocalTesting",
+  "advancedCommerceInfo": {
+    "descriptors": {
+      "description": "Abonnement Café — 5,99 € par mois",
+      "displayName": "Café Premium"
+    },
+    "items": [
+      {
+        "SKU": "com.example.sku.premium",
+        "description": "プレミアム機能",
+        "displayName": "プレミアム",
+        "price": 9990
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The problem

SignedDataVerifier.parseJWTPayload converts the base64url-decoded payload bytes into a String without specifying a charset:

String payload = new String(Base64.getUrlDecoder().decode(jwt.getPayload()));

new String(byte[]) uses the JVM default charset. A JWT Claims Set is always a UTF-8 encoded JSON object (RFC 7519 §3, RFC 8259 §8.1), so the two only agree when the JVM happens to run with UTF-8 as its default.

That is not guaranteed on the Java versions this library supports. JEP 400 made UTF-8 the default only in Java 18; on Java 11 through 17 the default charset comes from the platform locale, so a server running on Windows or with a non-UTF-8 LANG gets windows-1252, ISO-8859-1, Shift_JIS, and so on.

When that happens, every non-ASCII character in a decoded payload is corrupted silently. The signature is verified against the raw JWS, so verification still succeeds and no exception is raised — the caller simply receives mojibake. This affects every entry point that goes through decodeSignedObject: verifyAndDecodeTransaction, verifyAndDecodeRenewalInfo, verifyAndDecodeNotification, verifyAndDecodeAppTransaction and verifyAndDecodeRealtimeRequest.

It is easy to reach in practice. The Advanced Commerce descriptors and items carry merchant-supplied free text (displayName, description), so any app that is not English-only can hit it.

Reproduction

On JDK 17 with windows-1252 as the default charset, decoding a signed transaction whose advancedCommerceInfo.descriptors.description is Abonnement Café — 5,99 € par mois returns:

Abonnement CafÃ© â€” 5,99 â‚¬ par mois

The existing test suite cannot catch this: all of its payload fixtures are ASCII-only, and CI sets JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8, which hides the difference.

The fix

new String(bytes, StandardCharsets.UTF_8) — one argument.

Source encoding

The build does not set options.encoding, so javac reads the sources with the platform charset too. 25 files under src/main contain non-ASCII characters (typographic apostrophes in the javadoc), which means those are corrupted in locally built javadoc on a non-UTF-8 machine. It also makes a regression test for this bug impossible to write in the natural way: the expected string literal would be corrupted by the compiler in exactly the same way as the actual value, and the assertion would pass.

This PR sets options.encoding = 'UTF-8' on the JavaCompile tasks and on javadoc. Note that ci-prb.yml currently compensates for the missing setting with JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8, while ci-release-javadocs.yml does not set it at all.

The test

SignedDataVerifierTest.testNonAsciiDataDecodingIsIndependentOfTheDefaultCharset decodes a new fixture containing French and Japanese text. Its expected values are written as \uXXXX escape sequences, so the test source is pure ASCII and the assertion does not depend on the encoding used to compile it.

Verification

On JDK 17, default charset windows-1252:

- without the production change the new test fails with
expected: <Abonnement Café — 5,99 € par mois> but was: <Abonnement CafÃ© â€” 5,99 â‚¬ par mois>
- with it, ./gradlew clean test and ./gradlew javadoc both pass

Not included

Two related items I left out to keep the diff focused, happy to add them if you would prefer them here:

- the JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 line in ci-prb.yml is now redundant for compilation and could be dropped
- CI runs on a UTF-8 locale, so it would not catch a regression of this bug; a matrix entry running the tests with a non-UTF-8 default charset would lock the behavior in

I also did not touch CHANGELOG.md, since it appears to be updated by maintainers in the release commits.