### PR TITLE
Add AppReceiptVerifier for signature validation of legacy app receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,44 @@ public class ExampleMigration {
 }
 ```
 
+### App Receipt Verification Usage
+
+```java
+import com.apple.itunes.storekit.model.AppReceipt;
+import com.apple.itunes.storekit.model.Environment;
+import com.apple.itunes.storekit.verification.AppReceiptVerifier;
+import com.apple.itunes.storekit.verification.VerificationException;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Set;
+
+public class ExampleAppReceiptVerification {
+    public static void main(String[] args) {
+        String bundleId = "com.example";
+        Environment environment = Environment.SANDBOX;
+        Set<InputStream> rootCAs = Set.of(
+                new FileInputStream("/path/to/rootCA1"),
+                new FileInputStream("/path/to/rootCA2")
+        );
+
+        AppReceiptVerifier appReceiptVerifier = new AppReceiptVerifier(rootCAs, bundleId, environment, true);
+
+        String appReceipt = "MI...";
+
+        try {
+            AppReceipt receipt = appReceiptVerifier.verifyAndDecodeAppReceipt(appReceipt);
+            System.out.println(receipt);
+
+            String transactionId = appReceiptVerifier.verifyAndExtractTransactionId(appReceipt);
+            System.out.println(transactionId);
+        } catch (VerificationException e) {
+            e.printStackTrace();
+        }
+    }
+}
+```
+
 ### Promotional Offer Signature Creation
 
 ```java

--- a/README.md
+++ b/README.md
@@ -183,16 +183,19 @@ public class ExampleAppReceiptVerification {
                 new FileInputStream("/path/to/rootCA2")
         );
 
-        AppReceiptVerifier appReceiptVerifier = new AppReceiptVerifier(rootCAs, bundleId, environment, true);
+        // Online checks move chain validation to the current date. App receipts
+        // outlive the certificate that signed them, so leaving them off is what
+        // lets an old receipt still verify.
+        boolean enableOnlineChecks = false;
+
+        AppReceiptVerifier appReceiptVerifier = new AppReceiptVerifier(rootCAs, bundleId, environment, enableOnlineChecks);
 
         String appReceipt = "MI...";
 
         try {
             AppReceipt receipt = appReceiptVerifier.verifyAndDecodeAppReceipt(appReceipt);
             System.out.println(receipt);
-
-            String transactionId = appReceiptVerifier.verifyAndExtractTransactionId(appReceipt);
-            System.out.println(transactionId);
+            System.out.println(receipt.getInAppPurchases());
         } catch (VerificationException e) {
             e.printStackTrace();
         }

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.16.1'
     implementation 'com.auth0:java-jwt:4.5.1'
     implementation 'org.bouncycastle:bcprov-jdk18on:1.84'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.84'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/apple/itunes/storekit/migration/ReceiptUtility.java
+++ b/src/main/java/com/apple/itunes/storekit/migration/ReceiptUtility.java
@@ -30,6 +30,8 @@ public class ReceiptUtility {
     /**
      * Extracts a transaction id from an encoded App Receipt. Throws if the receipt does not match the expected format.
      * *NO validation* is performed on the receipt, and any data returned should only be used to call the App Store Server API.
+     * To verify the receipt's signature before extraction, use
+     * {@link com.apple.itunes.storekit.verification.AppReceiptVerifier#verifyAndExtractTransactionId(String)}.
      *
      * @param appReceipt The unmodified app receipt
      * @return A transaction id from the array of in-app purchases, null if the receipt contains no in-app purchases.

--- a/src/main/java/com/apple/itunes/storekit/model/AppReceipt.java
+++ b/src/main/java/com/apple/itunes/storekit/model/AppReceipt.java
@@ -1,0 +1,302 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+package com.apple.itunes.storekit.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A decoded legacy App Store receipt (the PKCS#7 app receipt).
+ *
+ * @see <a href="https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt">receipt</a>
+ */
+public class AppReceipt {
+
+    private String receiptType;
+    private String bundleId;
+    private byte[] bundleIdBytes;
+    private String applicationVersion;
+    private byte[] opaqueValue;
+    private byte[] sha1Hash;
+    private Long receiptCreationDate;
+    private Long originalPurchaseDate;
+    private String originalApplicationVersion;
+    private Long expirationDate;
+    private List<InAppPurchaseReceipt> inAppPurchases;
+    private Map<Integer, List<byte[]>> unknownAttributes;
+
+    public AppReceipt() {
+    }
+
+    public AppReceipt receiptType(String receiptType) {
+        this.receiptType = receiptType;
+        return this;
+    }
+
+    /**
+     * The raw receipt type, e.g. {@code Production}, {@code ProductionVPP},
+     * {@code ProductionSandbox}, {@code ProductionVPPSandbox} or {@code Xcode}.
+     *
+     * @return receiptType
+     */
+    public String getReceiptType() {
+        return receiptType;
+    }
+
+    public void setReceiptType(String receiptType) {
+        this.receiptType = receiptType;
+    }
+
+    public AppReceipt bundleId(String bundleId) {
+        this.bundleId = bundleId;
+        return this;
+    }
+
+    /**
+     * The bundle identifier of the app the receipt belongs to.
+     *
+     * @return bundleId
+     */
+    public String getBundleId() {
+        return bundleId;
+    }
+
+    public void setBundleId(String bundleId) {
+        this.bundleId = bundleId;
+    }
+
+    public AppReceipt bundleIdBytes(byte[] bundleIdBytes) {
+        this.bundleIdBytes = bundleIdBytes;
+        return this;
+    }
+
+    /**
+     * The raw ASN.1 bytes of the bundle identifier attribute, needed together
+     * with {@link #getOpaqueValue()} and {@link #getSha1Hash()} to compute the
+     * device-hash binding described in Apple's receipt validation guide.
+     *
+     * @return bundleIdBytes
+     */
+    public byte[] getBundleIdBytes() {
+        return bundleIdBytes;
+    }
+
+    public void setBundleIdBytes(byte[] bundleIdBytes) {
+        this.bundleIdBytes = bundleIdBytes;
+    }
+
+    public AppReceipt applicationVersion(String applicationVersion) {
+        this.applicationVersion = applicationVersion;
+        return this;
+    }
+
+    /**
+     * The app's version number.
+     *
+     * @return applicationVersion
+     */
+    public String getApplicationVersion() {
+        return applicationVersion;
+    }
+
+    public void setApplicationVersion(String applicationVersion) {
+        this.applicationVersion = applicationVersion;
+    }
+
+    public AppReceipt opaqueValue(byte[] opaqueValue) {
+        this.opaqueValue = opaqueValue;
+        return this;
+    }
+
+    /**
+     * An opaque value used, with other data, to compute the device hash.
+     *
+     * @return opaqueValue
+     */
+    public byte[] getOpaqueValue() {
+        return opaqueValue;
+    }
+
+    public void setOpaqueValue(byte[] opaqueValue) {
+        this.opaqueValue = opaqueValue;
+    }
+
+    public AppReceipt sha1Hash(byte[] sha1Hash) {
+        this.sha1Hash = sha1Hash;
+        return this;
+    }
+
+    /**
+     * The SHA-1 device-hash attribute of the receipt.
+     *
+     * @return sha1Hash
+     */
+    public byte[] getSha1Hash() {
+        return sha1Hash;
+    }
+
+    public void setSha1Hash(byte[] sha1Hash) {
+        this.sha1Hash = sha1Hash;
+    }
+
+    public AppReceipt receiptCreationDate(Long receiptCreationDate) {
+        this.receiptCreationDate = receiptCreationDate;
+        return this;
+    }
+
+    /**
+     * The time the App Store generated the receipt, in UNIX time, in
+     * milliseconds.
+     *
+     * @return receiptCreationDate
+     */
+    public Long getReceiptCreationDate() {
+        return receiptCreationDate;
+    }
+
+    public void setReceiptCreationDate(Long receiptCreationDate) {
+        this.receiptCreationDate = receiptCreationDate;
+    }
+
+    public AppReceipt originalPurchaseDate(Long originalPurchaseDate) {
+        this.originalPurchaseDate = originalPurchaseDate;
+        return this;
+    }
+
+    /**
+     * The time of the original app purchase, in UNIX time, in milliseconds.
+     *
+     * @return originalPurchaseDate
+     */
+    public Long getOriginalPurchaseDate() {
+        return originalPurchaseDate;
+    }
+
+    public void setOriginalPurchaseDate(Long originalPurchaseDate) {
+        this.originalPurchaseDate = originalPurchaseDate;
+    }
+
+    public AppReceipt originalApplicationVersion(String originalApplicationVersion) {
+        this.originalApplicationVersion = originalApplicationVersion;
+        return this;
+    }
+
+    /**
+     * The version of the app that the user originally purchased.
+     *
+     * @return originalApplicationVersion
+     */
+    public String getOriginalApplicationVersion() {
+        return originalApplicationVersion;
+    }
+
+    public void setOriginalApplicationVersion(String originalApplicationVersion) {
+        this.originalApplicationVersion = originalApplicationVersion;
+    }
+
+    public AppReceipt expirationDate(Long expirationDate) {
+        this.expirationDate = expirationDate;
+        return this;
+    }
+
+    /**
+     * The expiration date of the receipt, in UNIX time, in milliseconds.
+     * Present for apps purchased through the Volume Purchase Program.
+     *
+     * @return expirationDate
+     */
+    public Long getExpirationDate() {
+        return expirationDate;
+    }
+
+    public void setExpirationDate(Long expirationDate) {
+        this.expirationDate = expirationDate;
+    }
+
+    public AppReceipt inAppPurchases(List<InAppPurchaseReceipt> inAppPurchases) {
+        this.inAppPurchases = inAppPurchases;
+        return this;
+    }
+
+    /**
+     * The decoded in-app purchase attributes contained in the receipt.
+     *
+     * @return inAppPurchases
+     */
+    public List<InAppPurchaseReceipt> getInAppPurchases() {
+        return inAppPurchases != null ? inAppPurchases : Collections.emptyList();
+    }
+
+    public void setInAppPurchases(List<InAppPurchaseReceipt> inAppPurchases) {
+        this.inAppPurchases = inAppPurchases;
+    }
+
+    public AppReceipt unknownAttributes(Map<Integer, List<byte[]>> unknownAttributes) {
+        this.unknownAttributes = unknownAttributes;
+        return this;
+    }
+
+    /**
+     * Attribute types this library does not model, keyed by type, with the
+     * verified-but-undecoded value bytes, so fields Apple adds later remain
+     * accessible without a library update.
+     *
+     * @return unknownAttributes
+     */
+    public Map<Integer, List<byte[]>> getUnknownAttributes() {
+        return unknownAttributes != null ? unknownAttributes : Collections.emptyMap();
+    }
+
+    public void setUnknownAttributes(Map<Integer, List<byte[]>> unknownAttributes) {
+        this.unknownAttributes = unknownAttributes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AppReceipt that = (AppReceipt) o;
+        return Objects.equals(receiptType, that.receiptType)
+                && Objects.equals(bundleId, that.bundleId)
+                && Arrays.equals(bundleIdBytes, that.bundleIdBytes)
+                && Objects.equals(applicationVersion, that.applicationVersion)
+                && Arrays.equals(opaqueValue, that.opaqueValue)
+                && Arrays.equals(sha1Hash, that.sha1Hash)
+                && Objects.equals(receiptCreationDate, that.receiptCreationDate)
+                && Objects.equals(originalPurchaseDate, that.originalPurchaseDate)
+                && Objects.equals(originalApplicationVersion, that.originalApplicationVersion)
+                && Objects.equals(expirationDate, that.expirationDate)
+                && Objects.equals(inAppPurchases, that.inAppPurchases);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(receiptType, bundleId, applicationVersion, receiptCreationDate,
+                originalPurchaseDate, originalApplicationVersion, expirationDate, inAppPurchases);
+        result = 31 * result + Arrays.hashCode(bundleIdBytes);
+        result = 31 * result + Arrays.hashCode(opaqueValue);
+        result = 31 * result + Arrays.hashCode(sha1Hash);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "AppReceipt{" +
+                "receiptType='" + receiptType + '\'' +
+                ", bundleId='" + bundleId + '\'' +
+                ", applicationVersion='" + applicationVersion + '\'' +
+                ", receiptCreationDate=" + receiptCreationDate +
+                ", originalPurchaseDate=" + originalPurchaseDate +
+                ", originalApplicationVersion='" + originalApplicationVersion + '\'' +
+                ", expirationDate=" + expirationDate +
+                ", inAppPurchases=" + inAppPurchases +
+                '}';
+    }
+}

--- a/src/main/java/com/apple/itunes/storekit/model/InAppPurchaseReceipt.java
+++ b/src/main/java/com/apple/itunes/storekit/model/InAppPurchaseReceipt.java
@@ -1,0 +1,277 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+package com.apple.itunes.storekit.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A decoded in-app purchase attribute from a legacy App Store receipt.
+ *
+ * @see <a href="https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt/in_app">in_app</a>
+ */
+public class InAppPurchaseReceipt {
+
+    private Long quantity;
+    private String productId;
+    private String transactionId;
+    private String originalTransactionId;
+    private Long purchaseDate;
+    private Long originalPurchaseDate;
+    private Long expiresDate;
+    private Long cancellationDate;
+    private Long webOrderLineItemId;
+    private Boolean isInIntroOfferPeriod;
+    private Map<Integer, List<byte[]>> unknownAttributes;
+
+    public InAppPurchaseReceipt() {
+    }
+
+    public InAppPurchaseReceipt quantity(Long quantity) {
+        this.quantity = quantity;
+        return this;
+    }
+
+    /**
+     * The number of items purchased.
+     *
+     * @return quantity
+     */
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Long quantity) {
+        this.quantity = quantity;
+    }
+
+    public InAppPurchaseReceipt productId(String productId) {
+        this.productId = productId;
+        return this;
+    }
+
+    /**
+     * The unique identifier of the product purchased.
+     *
+     * @return productId
+     */
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public InAppPurchaseReceipt transactionId(String transactionId) {
+        this.transactionId = transactionId;
+        return this;
+    }
+
+    /**
+     * The unique identifier of the transaction.
+     *
+     * @return transactionId
+     */
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public InAppPurchaseReceipt originalTransactionId(String originalTransactionId) {
+        this.originalTransactionId = originalTransactionId;
+        return this;
+    }
+
+    /**
+     * The unique identifier of the original transaction.
+     *
+     * @return originalTransactionId
+     */
+    public String getOriginalTransactionId() {
+        return originalTransactionId;
+    }
+
+    public void setOriginalTransactionId(String originalTransactionId) {
+        this.originalTransactionId = originalTransactionId;
+    }
+
+    public InAppPurchaseReceipt purchaseDate(Long purchaseDate) {
+        this.purchaseDate = purchaseDate;
+        return this;
+    }
+
+    /**
+     * The time of the purchase, in UNIX time, in milliseconds.
+     *
+     * @return purchaseDate
+     */
+    public Long getPurchaseDate() {
+        return purchaseDate;
+    }
+
+    public void setPurchaseDate(Long purchaseDate) {
+        this.purchaseDate = purchaseDate;
+    }
+
+    public InAppPurchaseReceipt originalPurchaseDate(Long originalPurchaseDate) {
+        this.originalPurchaseDate = originalPurchaseDate;
+        return this;
+    }
+
+    /**
+     * The time of the original purchase, in UNIX time, in milliseconds.
+     *
+     * @return originalPurchaseDate
+     */
+    public Long getOriginalPurchaseDate() {
+        return originalPurchaseDate;
+    }
+
+    public void setOriginalPurchaseDate(Long originalPurchaseDate) {
+        this.originalPurchaseDate = originalPurchaseDate;
+    }
+
+    public InAppPurchaseReceipt expiresDate(Long expiresDate) {
+        this.expiresDate = expiresDate;
+        return this;
+    }
+
+    /**
+     * The expiration time of the subscription, in UNIX time, in milliseconds.
+     *
+     * @return expiresDate
+     */
+    public Long getExpiresDate() {
+        return expiresDate;
+    }
+
+    public void setExpiresDate(Long expiresDate) {
+        this.expiresDate = expiresDate;
+    }
+
+    public InAppPurchaseReceipt cancellationDate(Long cancellationDate) {
+        this.cancellationDate = cancellationDate;
+        return this;
+    }
+
+    /**
+     * The time Apple customer support canceled the transaction or the
+     * subscription was upgraded, in UNIX time, in milliseconds.
+     *
+     * @return cancellationDate
+     */
+    public Long getCancellationDate() {
+        return cancellationDate;
+    }
+
+    public void setCancellationDate(Long cancellationDate) {
+        this.cancellationDate = cancellationDate;
+    }
+
+    public InAppPurchaseReceipt webOrderLineItemId(Long webOrderLineItemId) {
+        this.webOrderLineItemId = webOrderLineItemId;
+        return this;
+    }
+
+    /**
+     * The unique identifier of subscription purchase events across devices,
+     * including subscription renewals.
+     *
+     * @return webOrderLineItemId
+     */
+    public Long getWebOrderLineItemId() {
+        return webOrderLineItemId;
+    }
+
+    public void setWebOrderLineItemId(Long webOrderLineItemId) {
+        this.webOrderLineItemId = webOrderLineItemId;
+    }
+
+    public InAppPurchaseReceipt isInIntroOfferPeriod(Boolean isInIntroOfferPeriod) {
+        this.isInIntroOfferPeriod = isInIntroOfferPeriod;
+        return this;
+    }
+
+    /**
+     * Whether the subscription is in an introductory offer period.
+     *
+     * @return isInIntroOfferPeriod
+     */
+    public Boolean getIsInIntroOfferPeriod() {
+        return isInIntroOfferPeriod;
+    }
+
+    public void setIsInIntroOfferPeriod(Boolean isInIntroOfferPeriod) {
+        this.isInIntroOfferPeriod = isInIntroOfferPeriod;
+    }
+
+    public InAppPurchaseReceipt unknownAttributes(Map<Integer, List<byte[]>> unknownAttributes) {
+        this.unknownAttributes = unknownAttributes;
+        return this;
+    }
+
+    /**
+     * Attribute types this library does not model, keyed by type, with the
+     * verified-but-undecoded value bytes, so fields Apple adds later remain
+     * accessible without a library update.
+     *
+     * @return unknownAttributes
+     */
+    public Map<Integer, List<byte[]>> getUnknownAttributes() {
+        return unknownAttributes != null ? unknownAttributes : Collections.emptyMap();
+    }
+
+    public void setUnknownAttributes(Map<Integer, List<byte[]>> unknownAttributes) {
+        this.unknownAttributes = unknownAttributes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InAppPurchaseReceipt that = (InAppPurchaseReceipt) o;
+        return Objects.equals(quantity, that.quantity)
+                && Objects.equals(productId, that.productId)
+                && Objects.equals(transactionId, that.transactionId)
+                && Objects.equals(originalTransactionId, that.originalTransactionId)
+                && Objects.equals(purchaseDate, that.purchaseDate)
+                && Objects.equals(originalPurchaseDate, that.originalPurchaseDate)
+                && Objects.equals(expiresDate, that.expiresDate)
+                && Objects.equals(cancellationDate, that.cancellationDate)
+                && Objects.equals(webOrderLineItemId, that.webOrderLineItemId)
+                && Objects.equals(isInIntroOfferPeriod, that.isInIntroOfferPeriod);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(quantity, productId, transactionId, originalTransactionId,
+                purchaseDate, originalPurchaseDate, expiresDate, cancellationDate,
+                webOrderLineItemId, isInIntroOfferPeriod);
+    }
+
+    @Override
+    public String toString() {
+        return "InAppPurchaseReceipt{" +
+                "quantity=" + quantity +
+                ", productId='" + productId + '\'' +
+                ", transactionId='" + transactionId + '\'' +
+                ", originalTransactionId='" + originalTransactionId + '\'' +
+                ", purchaseDate=" + purchaseDate +
+                ", originalPurchaseDate=" + originalPurchaseDate +
+                ", expiresDate=" + expiresDate +
+                ", cancellationDate=" + cancellationDate +
+                ", webOrderLineItemId=" + webOrderLineItemId +
+                ", isInIntroOfferPeriod=" + isInIntroOfferPeriod +
+                '}';
+    }
+}

--- a/src/main/java/com/apple/itunes/storekit/verification/AppReceiptVerifier.java
+++ b/src/main/java/com/apple/itunes/storekit/verification/AppReceiptVerifier.java
@@ -1,0 +1,472 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+package com.apple.itunes.storekit.verification;
+
+import com.apple.itunes.storekit.model.AppReceipt;
+import com.apple.itunes.storekit.model.Environment;
+import com.apple.itunes.storekit.model.InAppPurchaseReceipt;
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.ASN1Set;
+import org.bouncycastle.asn1.ASN1String;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cms.CMSException;
+import org.bouncycastle.cms.CMSSignedData;
+import org.bouncycastle.cms.SignerInformation;
+import org.bouncycastle.cms.jcajce.JcaSimpleSignerInfoVerifierBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.OperatorCreationException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A verifier and decoder class for legacy PKCS#7 App Store receipts (the app
+ * receipt used with the deprecated {@code verifyReceipt} endpoint).
+ *
+ * <p>This is the validating counterpart to
+ * {@link com.apple.itunes.storekit.migration.ReceiptUtility}, which extracts
+ * without validation. The receipt's certificate chain is validated with the
+ * same {@link ChainVerifier} used for JWS signed data, against the same
+ * caller-supplied Apple root certificates, and evaluated at the receipt's
+ * creation date so old receipts survive certificate rotations unless online
+ * checks are enabled.</p>
+ */
+public class AppReceiptVerifier {
+
+    private static final int ATTR_RECEIPT_TYPE = 0;
+    private static final int ATTR_BUNDLE_ID = 2;
+    private static final int ATTR_APP_VERSION = 3;
+    private static final int ATTR_OPAQUE_VALUE = 4;
+    private static final int ATTR_SHA1_HASH = 5;
+    private static final int ATTR_CREATION_DATE = 12;
+    private static final int ATTR_IN_APP = 17;
+    private static final int ATTR_ORIGINAL_PURCHASE_DATE = 18;
+    private static final int ATTR_ORIGINAL_APP_VERSION = 19;
+    private static final int ATTR_EXPIRATION_DATE = 21;
+
+    private static final int IAP_QUANTITY = 1701;
+    private static final int IAP_PRODUCT_ID = 1702;
+    private static final int IAP_TRANSACTION_ID = 1703;
+    private static final int IAP_PURCHASE_DATE = 1704;
+    private static final int IAP_ORIGINAL_TRANSACTION_ID = 1705;
+    private static final int IAP_ORIGINAL_PURCHASE_DATE = 1706;
+    private static final int IAP_EXPIRES_DATE = 1708;
+    private static final int IAP_WEB_ORDER_LINE_ITEM_ID = 1711;
+    private static final int IAP_CANCELLATION_DATE = 1712;
+    private static final int IAP_IS_IN_INTRO_OFFER_PERIOD = 1719;
+
+    private static final String SHA1_OID = "1.3.14.3.2.26";
+    private static final String SHA256_OID = "2.16.840.1.101.3.4.2.1";
+
+    private final String bundleId;
+    private final Environment environment;
+    private final ChainVerifier chainVerifier;
+    private final boolean enableOnlineChecks;
+    private final BouncyCastleProvider bouncyCastleProvider = new BouncyCastleProvider();
+
+    /**
+     * @param rootCertificates The set of Apple Root certificate authority certificates, as found on <a href="https://www.apple.com/certificateauthority/">Apple PKI</a>
+     * @param bundleId The bundle identifier of the app
+     * @param environment The server environment, either sandbox or production
+     * @param enableOnlineChecks Whether to enable revocation checking and check expiration using the current date
+     */
+    public AppReceiptVerifier(Set<InputStream> rootCertificates, String bundleId, Environment environment, boolean enableOnlineChecks) {
+        this.bundleId = bundleId;
+        this.environment = environment;
+        this.chainVerifier = Environment.XCODE.equals(environment) || Environment.LOCAL_TESTING.equals(environment) ? null : new ChainVerifier(rootCertificates);
+        this.enableOnlineChecks = enableOnlineChecks;
+    }
+
+    /**
+     * Verifies and decodes an app receipt, as obtained from a device.
+     * @see <a href="https://developer.apple.com/documentation/appstorereceipts">App Store Receipts</a>
+     *
+     * @param encodedReceipt The base64-encoded app receipt
+     * @return The decoded receipt after verification
+     * @throws VerificationException Thrown if the receipt could not be verified
+     */
+    public AppReceipt verifyAndDecodeAppReceipt(String encodedReceipt) throws VerificationException {
+        byte[] receiptDer;
+        try {
+            receiptDer = Base64.getMimeDecoder().decode(encodedReceipt);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Receipt is not valid base64");
+        }
+        CMSSignedData signedData;
+        try {
+            // fromByteArray throws when parsing does not exhaust the input,
+            // rejecting trailing bytes after the CMS blob.
+            ASN1Primitive.fromByteArray(receiptDer);
+            signedData = new CMSSignedData(receiptDer);
+        } catch (IOException | CMSException e) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Receipt is not a PKCS#7 container");
+        }
+        if (signedData.getSignedContent() == null || !(signedData.getSignedContent().getContent() instanceof byte[])) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Receipt has no encapsulated payload");
+        }
+        // Parsed before signature verification only to learn the creation
+        // date (chain validity is anchored at signing time); nothing from it
+        // is trusted until the chain and signature checks pass.
+        AppReceipt receipt = parseReceiptPayload((byte[]) signedData.getSignedContent().getContent());
+        if (!Environment.XCODE.equals(this.environment) && !Environment.LOCAL_TESTING.equals(this.environment)) {
+            Date effectiveDate = this.enableOnlineChecks || receipt.getReceiptCreationDate() == null ? new Date() : new Date(receipt.getReceiptCreationDate());
+            X509Certificate signerCertificate = verifyChain(signedData, effectiveDate);
+            verifySignature(signedData, signerCertificate);
+        }
+        // In the Xcode and LocalTesting environments the data is not signed by
+        // the App Store and signature verification is skipped, but the bundle
+        // id and environment are still validated.
+        validateBundleId(receipt.getBundleId());
+        validateEnvironment(environmentForReceiptType(receipt.getReceiptType()));
+        return receipt;
+    }
+
+    /**
+     * Verifies an app receipt and extracts a transaction id from its in-app
+     * purchases — the validated counterpart of
+     * {@link com.apple.itunes.storekit.migration.ReceiptUtility#extractTransactionIdFromAppReceipt(String)},
+     * with the same output contract: a transaction id from the array of
+     * in-app purchases, or null if the receipt contains none.
+     *
+     * @param encodedReceipt The base64-encoded app receipt
+     * @return A transaction id from the receipt's in-app purchases, null if the receipt contains no in-app purchases
+     * @throws VerificationException Thrown if the receipt could not be verified
+     */
+    public String verifyAndExtractTransactionId(String encodedReceipt) throws VerificationException {
+        AppReceipt receipt = verifyAndDecodeAppReceipt(encodedReceipt);
+        for (InAppPurchaseReceipt purchase : receipt.getInAppPurchases()) {
+            if (purchase.getTransactionId() != null) {
+                return purchase.getTransactionId();
+            }
+            if (purchase.getOriginalTransactionId() != null) {
+                return purchase.getOriginalTransactionId();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Orders the receipt's embedded certificates as leaf, intermediate, root
+     * and hands them to the shared {@link ChainVerifier}, which enforces the
+     * chain length, the WWDR intermediate OID and the receipt-signing leaf
+     * OID, and validates to the caller-supplied Apple roots.
+     */
+    private X509Certificate verifyChain(CMSSignedData signedData, Date effectiveDate) throws VerificationException {
+        SignerInformation signer = firstSigner(signedData);
+        JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
+        try {
+            List<X509Certificate> embedded = new ArrayList<>();
+            for (X509CertificateHolder holder : signedData.getCertificates().getMatches(null)) {
+                embedded.add(converter.getCertificate(holder));
+            }
+            X509Certificate leaf = null;
+            Collection<X509CertificateHolder> signerMatches = signedData.getCertificates().getMatches(signer.getSID());
+            if (!signerMatches.isEmpty()) {
+                leaf = converter.getCertificate(signerMatches.iterator().next());
+            }
+            if (leaf == null) {
+                throw new VerificationException(VerificationStatus.INVALID_CHAIN, "Signer certificate is not embedded in the receipt");
+            }
+            List<X509Certificate> ordered = new ArrayList<>();
+            ordered.add(leaf);
+            X509Certificate current = leaf;
+            while (ordered.size() < embedded.size()) {
+                X509Certificate issuer = findIssuer(current, embedded, ordered);
+                if (issuer == null) {
+                    break;
+                }
+                ordered.add(issuer);
+                current = issuer;
+            }
+            String[] encodedChain = new String[ordered.size()];
+            for (int i = 0; i < ordered.size(); i++) {
+                encodedChain[i] = Base64.getEncoder().encodeToString(ordered.get(i).getEncoded());
+            }
+            chainVerifier.verifyChain(encodedChain, enableOnlineChecks, effectiveDate);
+            return leaf;
+        } catch (CertificateException e) {
+            throw new VerificationException(VerificationStatus.INVALID_CERTIFICATE, e);
+        }
+    }
+
+    private static X509Certificate findIssuer(X509Certificate cert, List<X509Certificate> candidates, List<X509Certificate> exclude) {
+        for (X509Certificate candidate : candidates) {
+            if (!exclude.contains(candidate) && candidate.getSubjectX500Principal().equals(cert.getIssuerX500Principal())) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private void verifySignature(CMSSignedData signedData, X509Certificate signerCertificate) throws VerificationException {
+        if (!(signerCertificate.getPublicKey() instanceof RSAPublicKey)) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Receipt signer key is not RSA");
+        }
+        SignerInformation signer = firstSigner(signedData);
+        String digestOid = signer.getDigestAlgOID();
+        if (!SHA1_OID.equals(digestOid) && !SHA256_OID.equals(digestOid)) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Unrecognized receipt digest algorithm " + digestOid);
+        }
+        try {
+            if (!signer.verify(new JcaSimpleSignerInfoVerifierBuilder().setProvider(bouncyCastleProvider).build(signerCertificate))) {
+                throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Receipt signature does not verify");
+            }
+        } catch (CMSException | OperatorCreationException e) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, e);
+        }
+    }
+
+    private static SignerInformation firstSigner(CMSSignedData signedData) throws VerificationException {
+        for (SignerInformation signer : signedData.getSignerInfos().getSigners()) {
+            return signer;
+        }
+        throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Receipt has no signer info");
+    }
+
+    protected void validateBundleId(String bundleId) throws VerificationException {
+        if (this.bundleId == null || !this.bundleId.equals(bundleId)) {
+            throw new VerificationException(VerificationStatus.INVALID_APP_IDENTIFIER);
+        }
+    }
+
+    protected void validateEnvironment(Environment environment) throws VerificationException {
+        if (!this.environment.equals(environment)) {
+            throw new VerificationException(VerificationStatus.INVALID_ENVIRONMENT);
+        }
+    }
+
+    /**
+     * Maps the receipt-type attribute to a server environment. Only explicit
+     * production values map to {@link Environment#PRODUCTION}; unknown or
+     * missing values map to null and fail environment validation.
+     */
+    private static Environment environmentForReceiptType(String receiptType) {
+        if (receiptType == null) {
+            return null;
+        }
+        switch (receiptType) {
+            case "Production":
+            case "ProductionVPP":
+                return Environment.PRODUCTION;
+            case "ProductionSandbox":
+            case "ProductionVPPSandbox":
+                return Environment.SANDBOX;
+            case "Xcode":
+                return Environment.XCODE;
+            case "LocalTesting":
+                return Environment.LOCAL_TESTING;
+            default:
+                return null;
+        }
+    }
+
+    // --- ASN.1 payload parsing -------------------------------------------
+
+    private static AppReceipt parseReceiptPayload(byte[] payload) throws VerificationException {
+        AppReceipt receipt = new AppReceipt();
+        List<InAppPurchaseReceipt> inAppPurchases = new ArrayList<>();
+        Map<Integer, List<byte[]>> unknownAttributes = new LinkedHashMap<>();
+        for (ASN1Encodable element : parseAttributeSet(payload, "Receipt payload")) {
+            ReceiptAttribute attribute = ReceiptAttribute.of(element);
+            switch (attribute.type) {
+                case ATTR_RECEIPT_TYPE:
+                    receipt.setReceiptType(decodeString(attribute.value));
+                    break;
+                case ATTR_BUNDLE_ID:
+                    receipt.setBundleId(decodeString(attribute.value));
+                    receipt.setBundleIdBytes(attribute.value);
+                    break;
+                case ATTR_APP_VERSION:
+                    receipt.setApplicationVersion(decodeString(attribute.value));
+                    break;
+                case ATTR_OPAQUE_VALUE:
+                    receipt.setOpaqueValue(attribute.value);
+                    break;
+                case ATTR_SHA1_HASH:
+                    receipt.setSha1Hash(attribute.value);
+                    break;
+                case ATTR_CREATION_DATE:
+                    receipt.setReceiptCreationDate(decodeDate(attribute.value));
+                    break;
+                case ATTR_IN_APP:
+                    inAppPurchases.add(parseInAppPurchase(attribute.value));
+                    break;
+                case ATTR_ORIGINAL_PURCHASE_DATE:
+                    receipt.setOriginalPurchaseDate(decodeDate(attribute.value));
+                    break;
+                case ATTR_ORIGINAL_APP_VERSION:
+                    receipt.setOriginalApplicationVersion(decodeString(attribute.value));
+                    break;
+                case ATTR_EXPIRATION_DATE:
+                    receipt.setExpirationDate(decodeDate(attribute.value));
+                    break;
+                default:
+                    recordUnknown(unknownAttributes, attribute);
+                    break;
+            }
+        }
+        receipt.setInAppPurchases(inAppPurchases);
+        receipt.setUnknownAttributes(unknownAttributes);
+        return receipt;
+    }
+
+    private static InAppPurchaseReceipt parseInAppPurchase(byte[] inAppSet) throws VerificationException {
+        InAppPurchaseReceipt purchase = new InAppPurchaseReceipt();
+        Map<Integer, List<byte[]>> unknownAttributes = new LinkedHashMap<>();
+        for (ASN1Encodable element : parseAttributeSet(inAppSet, "In-app purchase attribute")) {
+            ReceiptAttribute attribute = ReceiptAttribute.of(element);
+            switch (attribute.type) {
+                case IAP_QUANTITY:
+                    purchase.setQuantity(decodeInteger(attribute.value));
+                    break;
+                case IAP_PRODUCT_ID:
+                    purchase.setProductId(decodeString(attribute.value));
+                    break;
+                case IAP_TRANSACTION_ID:
+                    purchase.setTransactionId(decodeString(attribute.value));
+                    break;
+                case IAP_PURCHASE_DATE:
+                    purchase.setPurchaseDate(decodeDate(attribute.value));
+                    break;
+                case IAP_ORIGINAL_TRANSACTION_ID:
+                    purchase.setOriginalTransactionId(decodeString(attribute.value));
+                    break;
+                case IAP_ORIGINAL_PURCHASE_DATE:
+                    purchase.setOriginalPurchaseDate(decodeDate(attribute.value));
+                    break;
+                case IAP_EXPIRES_DATE:
+                    purchase.setExpiresDate(decodeDate(attribute.value));
+                    break;
+                case IAP_WEB_ORDER_LINE_ITEM_ID:
+                    purchase.setWebOrderLineItemId(decodeInteger(attribute.value));
+                    break;
+                case IAP_CANCELLATION_DATE:
+                    purchase.setCancellationDate(decodeDate(attribute.value));
+                    break;
+                case IAP_IS_IN_INTRO_OFFER_PERIOD:
+                    Long flag = decodeInteger(attribute.value);
+                    purchase.setIsInIntroOfferPeriod(flag != null && flag != 0);
+                    break;
+                default:
+                    recordUnknown(unknownAttributes, attribute);
+                    break;
+            }
+        }
+        purchase.setUnknownAttributes(unknownAttributes);
+        return purchase;
+    }
+
+    private static void recordUnknown(Map<Integer, List<byte[]>> unknownAttributes, ReceiptAttribute attribute) {
+        unknownAttributes.computeIfAbsent(attribute.type, k -> new ArrayList<>()).add(attribute.value);
+    }
+
+    private static ASN1Set parseAttributeSet(byte[] der, String what) throws VerificationException {
+        ASN1Primitive parsed;
+        try {
+            parsed = ASN1Primitive.fromByteArray(der);
+            if (parsed instanceof ASN1OctetString) {
+                // Xcode receipts double-wrap the payload in an extra OCTET
+                // STRING; ReceiptUtility handles the same shape.
+                parsed = ASN1Primitive.fromByteArray(((ASN1OctetString) parsed).getOctets());
+            }
+        } catch (IOException e) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, what + " is not valid ASN.1");
+        }
+        if (!(parsed instanceof ASN1Set)) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, what + " is not an ASN.1 SET");
+        }
+        return (ASN1Set) parsed;
+    }
+
+    /** {@code ReceiptAttribute ::= SEQUENCE { type INTEGER, version INTEGER, value OCTET STRING }} */
+    private static final class ReceiptAttribute {
+        final int type;
+        final byte[] value;
+
+        private ReceiptAttribute(int type, byte[] value) {
+            this.type = type;
+            this.value = value;
+        }
+
+        static ReceiptAttribute of(ASN1Encodable element) throws VerificationException {
+            try {
+                ASN1Sequence sequence = ASN1Sequence.getInstance(element);
+                if (sequence.size() < 3) {
+                    throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Receipt attribute has " + sequence.size() + " fields, expected 3");
+                }
+                long type = boundedLong(ASN1Integer.getInstance(sequence.getObjectAt(0)).getValue());
+                byte[] value = ASN1OctetString.getInstance(sequence.getObjectAt(2)).getOctets();
+                // A type beyond int range matches no known attribute; -1 routes
+                // it to unknownAttributes instead of aliasing via a truncating cast.
+                int typeInt = type >= 0 && type <= Integer.MAX_VALUE ? (int) type : -1;
+                return new ReceiptAttribute(typeInt, value);
+            } catch (IllegalArgumentException e) {
+                throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Malformed receipt attribute");
+            }
+        }
+    }
+
+    /** Non-negative and within long range — real receipts carry 7-byte integers. */
+    private static long boundedLong(BigInteger value) throws VerificationException {
+        if (value.signum() < 0 || value.bitLength() > 63) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Receipt integer out of range");
+        }
+        return value.longValue();
+    }
+
+    private static String decodeString(byte[] der) throws VerificationException {
+        try {
+            ASN1Primitive parsed = ASN1Primitive.fromByteArray(der);
+            if (!(parsed instanceof ASN1String)) {
+                throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Attribute value is not an ASN.1 string");
+            }
+            return ((ASN1String) parsed).getString();
+        } catch (IOException e) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Attribute value is not valid ASN.1");
+        }
+    }
+
+    private static Long decodeInteger(byte[] der) throws VerificationException {
+        try {
+            ASN1Primitive parsed = ASN1Primitive.fromByteArray(der);
+            if (!(parsed instanceof ASN1Integer)) {
+                throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Attribute value is not an ASN.1 integer");
+            }
+            return boundedLong(((ASN1Integer) parsed).getValue());
+        } catch (IOException e) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Attribute value is not valid ASN.1");
+        }
+    }
+
+    /** RFC 3339 date in an IA5String, in milliseconds; empty means absent (real receipts do this). */
+    private static Long decodeDate(byte[] der) throws VerificationException {
+        String text = decodeString(der);
+        if (text.isEmpty()) {
+            return null;
+        }
+        try {
+            return Instant.parse(text).toEpochMilli();
+        } catch (DateTimeParseException e) {
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Unparseable receipt date: " + text);
+        }
+    }
+}

--- a/src/main/java/com/apple/itunes/storekit/verification/AppReceiptVerifier.java
+++ b/src/main/java/com/apple/itunes/storekit/verification/AppReceiptVerifier.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -48,6 +49,12 @@ import java.util.Set;
  * caller-supplied Apple root certificates, and evaluated at the receipt's
  * creation date so old receipts survive certificate rotations unless online
  * checks are enabled.</p>
+ *
+ * <p>Verification establishes that the App Store issued the receipt for this
+ * app, not that the presenter is the device the receipt was issued to. Binding
+ * a receipt to a device requires the device identifier, which a server does not
+ * have; {@link AppReceipt#getOpaqueValue()} and {@link AppReceipt#getSha1Hash()}
+ * are decoded so a caller in a position to do that check can.</p>
  */
 public class AppReceiptVerifier {
 
@@ -75,6 +82,8 @@ public class AppReceiptVerifier {
 
     private static final String SHA1_OID = "1.3.14.3.2.26";
     private static final String SHA256_OID = "2.16.840.1.101.3.4.2.1";
+
+    private static final int MAXIMUM_EMBEDDED_CERTIFICATES = 10;
 
     private final String bundleId;
     private final Environment environment;
@@ -104,6 +113,19 @@ public class AppReceiptVerifier {
      * @throws VerificationException Thrown if the receipt could not be verified
      */
     public AppReceipt verifyAndDecodeAppReceipt(String encodedReceipt) throws VerificationException {
+        try {
+            return verifyAndDecode(encodedReceipt);
+        } catch (VerificationException e) {
+            throw e;
+        } catch (Exception e) {
+            // As in SignedDataVerifier, anything hostile input can provoke
+            // surfaces as a verification failure rather than escaping the
+            // declared contract as a runtime exception.
+            throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, e);
+        }
+    }
+
+    private AppReceipt verifyAndDecode(String encodedReceipt) throws VerificationException {
         byte[] receiptDer;
         try {
             // The MIME decoder tolerates the line breaks base64 receipts
@@ -130,8 +152,11 @@ public class AppReceiptVerifier {
         AppReceipt receipt = parseReceiptPayload((byte[]) signedData.getSignedContent().getContent());
         if (!Environment.XCODE.equals(this.environment) && !Environment.LOCAL_TESTING.equals(this.environment)) {
             Date effectiveDate = this.enableOnlineChecks || receipt.getReceiptCreationDate() == null ? new Date() : new Date(receipt.getReceiptCreationDate());
-            X509Certificate signerCertificate = verifyChain(signedData, effectiveDate);
-            verifySignature(signedData, signerCertificate);
+            // Resolved once, so that the certificate the chain is built for is
+            // by construction the certificate the signature is verified with.
+            SignerInformation signer = firstSigner(signedData);
+            X509Certificate signerCertificate = verifyChain(signedData, signer, effectiveDate);
+            verifySignature(signer, signerCertificate);
         }
         // In the Xcode and LocalTesting environments the data is not signed by
         // the App Store and signature verification is skipped, but the bundle
@@ -171,13 +196,20 @@ public class AppReceiptVerifier {
      * chain length, the WWDR intermediate OID and the receipt-signing leaf
      * OID, and validates to the caller-supplied Apple roots.
      */
-    private X509Certificate verifyChain(CMSSignedData signedData, Date effectiveDate) throws VerificationException {
-        SignerInformation signer = firstSigner(signedData);
+    private X509Certificate verifyChain(CMSSignedData signedData, SignerInformation signer, Date effectiveDate) throws VerificationException {
         JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
         try {
+            Collection<X509CertificateHolder> holders = signedData.getCertificates().getMatches(null);
+            // A receipt embeds the leaf, the WWDR intermediate and the root.
+            // Bounding the count keeps a receipt carrying thousands of
+            // certificates from making chain assembly expensive, all of which
+            // would happen before anything about it has been verified.
+            if (holders.size() > MAXIMUM_EMBEDDED_CERTIFICATES) {
+                throw new VerificationException(VerificationStatus.INVALID_CHAIN_LENGTH);
+            }
             List<X509Certificate> embedded = new ArrayList<>();
             X509Certificate leaf = null;
-            for (X509CertificateHolder holder : signedData.getCertificates().getMatches(null)) {
+            for (X509CertificateHolder holder : holders) {
                 X509Certificate certificate = converter.getCertificate(holder);
                 embedded.add(certificate);
                 if (leaf == null && signer.getSID().match(holder)) {
@@ -218,11 +250,10 @@ public class AppReceiptVerifier {
         return null;
     }
 
-    private void verifySignature(CMSSignedData signedData, X509Certificate signerCertificate) throws VerificationException {
+    private void verifySignature(SignerInformation signer, X509Certificate signerCertificate) throws VerificationException {
         if (!(signerCertificate.getPublicKey() instanceof RSAPublicKey)) {
             throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Receipt signer key is not RSA");
         }
-        SignerInformation signer = firstSigner(signedData);
         String digestOid = signer.getDigestAlgOID();
         if (!SHA1_OID.equals(digestOid) && !SHA256_OID.equals(digestOid)) {
             throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Unrecognized receipt digest algorithm " + digestOid);

--- a/src/main/java/com/apple/itunes/storekit/verification/AppReceiptVerifier.java
+++ b/src/main/java/com/apple/itunes/storekit/verification/AppReceiptVerifier.java
@@ -31,7 +31,6 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -107,6 +106,8 @@ public class AppReceiptVerifier {
     public AppReceipt verifyAndDecodeAppReceipt(String encodedReceipt) throws VerificationException {
         byte[] receiptDer;
         try {
+            // The MIME decoder tolerates the line breaks base64 receipts
+            // commonly pick up in transit.
             receiptDer = Base64.getMimeDecoder().decode(encodedReceipt);
         } catch (IllegalArgumentException | NullPointerException e) {
             throw new VerificationException(VerificationStatus.VERIFICATION_FAILURE, "Receipt is not valid base64");
@@ -175,13 +176,13 @@ public class AppReceiptVerifier {
         JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
         try {
             List<X509Certificate> embedded = new ArrayList<>();
-            for (X509CertificateHolder holder : signedData.getCertificates().getMatches(null)) {
-                embedded.add(converter.getCertificate(holder));
-            }
             X509Certificate leaf = null;
-            Collection<X509CertificateHolder> signerMatches = signedData.getCertificates().getMatches(signer.getSID());
-            if (!signerMatches.isEmpty()) {
-                leaf = converter.getCertificate(signerMatches.iterator().next());
+            for (X509CertificateHolder holder : signedData.getCertificates().getMatches(null)) {
+                X509Certificate certificate = converter.getCertificate(holder);
+                embedded.add(certificate);
+                if (leaf == null && signer.getSID().match(holder)) {
+                    leaf = certificate;
+                }
             }
             if (leaf == null) {
                 throw new VerificationException(VerificationStatus.INVALID_CHAIN, "Signer certificate is not embedded in the receipt");
@@ -243,7 +244,7 @@ public class AppReceiptVerifier {
     }
 
     protected void validateBundleId(String bundleId) throws VerificationException {
-        if (this.bundleId == null || !this.bundleId.equals(bundleId)) {
+        if (!this.bundleId.equals(bundleId)) {
             throw new VerificationException(VerificationStatus.INVALID_APP_IDENTIFIER);
         }
     }
@@ -279,7 +280,6 @@ public class AppReceiptVerifier {
         }
     }
 
-    // --- ASN.1 payload parsing -------------------------------------------
 
     private static AppReceipt parseReceiptPayload(byte[] payload) throws VerificationException {
         AppReceipt receipt = new AppReceipt();

--- a/src/test/java/com/apple/itunes/storekit/util/ReceiptCreator.java
+++ b/src/test/java/com/apple/itunes/storekit/util/ReceiptCreator.java
@@ -41,6 +41,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -132,15 +133,45 @@ public class ReceiptCreator {
         return signReceipt(payload, chain.size(), signingTime);
     }
 
+    /**
+     * @param signatureAlgorithm The algorithm the signer signs with and names in
+     *                           the signer info, e.g. a digest Apple does not use
+     */
+    public byte[] signReceipt(byte[] payload, String signatureAlgorithm) throws Exception {
+        return signReceipt(payload, chain, new Date(), signatureAlgorithm);
+    }
+
+    /**
+     * A receipt embedding unrelated certificates on top of the chain, as one
+     * bloated to make chain assembly expensive carries.
+     */
+    public byte[] signReceiptWithPadding(byte[] payload, int paddingCertificates) throws Exception {
+        List<X509Certificate> embedded = new ArrayList<>(chain);
+        for (int i = 0; i < paddingCertificates; i++) {
+            KeyPair keyPair = rsaKeyPair();
+            embedded.add(certificate("CN=Padding " + i, keyPair.getPublic(), "CN=Test WWDR CA", keyPair.getPrivate(), false, null, tenYearsAgo(), inOneYear()));
+        }
+        return signReceipt(payload, embedded, new Date(), SIGNATURE_ALGORITHM);
+    }
+
+    /** A receipt signed by the leaf but embedding only the certificates above it. */
+    public byte[] signReceiptWithoutSignerCertificate(byte[] payload) throws Exception {
+        return signReceipt(payload, chain.subList(1, chain.size()), new Date(), SIGNATURE_ALGORITHM);
+    }
+
     private byte[] signReceipt(byte[] payload, int embeddedCertificates, Date signingTime) throws Exception {
+        return signReceipt(payload, chain.subList(0, embeddedCertificates), signingTime, SIGNATURE_ALGORITHM);
+    }
+
+    private byte[] signReceipt(byte[] payload, List<X509Certificate> embedded, Date signingTime, String signatureAlgorithm) throws Exception {
         ASN1EncodableVector signedAttributes = new ASN1EncodableVector();
         signedAttributes.add(new Attribute(CMSAttributes.signingTime, new DERSet(new Time(signingTime))));
         CMSSignedDataGenerator generator = new CMSSignedDataGenerator();
-        ContentSigner contentSigner = new JcaContentSignerBuilder(SIGNATURE_ALGORITHM).build(signingKey);
+        ContentSigner contentSigner = new JcaContentSignerBuilder(signatureAlgorithm).build(signingKey);
         generator.addSignerInfoGenerator(new JcaSignerInfoGeneratorBuilder(new JcaDigestCalculatorProviderBuilder().setProvider(BOUNCY_CASTLE_PROVIDER).build())
                 .setSignedAttributeGenerator(new DefaultSignedAttributeTableGenerator(new AttributeTable(signedAttributes)))
                 .build(contentSigner, chain.get(0)));
-        generator.addCertificates(new JcaCertStore(chain.subList(0, embeddedCertificates)));
+        generator.addCertificates(new JcaCertStore(embedded));
         return generator.generate(new CMSProcessableByteArray(payload), true).getEncoded();
     }
 

--- a/src/test/java/com/apple/itunes/storekit/util/ReceiptCreator.java
+++ b/src/test/java/com/apple/itunes/storekit/util/ReceiptCreator.java
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+package com.apple.itunes.storekit.util;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERIA5String;
+import org.bouncycastle.asn1.DERNull;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.DERSet;
+import org.bouncycastle.asn1.DERUTF8String;
+import org.bouncycastle.asn1.cms.Attribute;
+import org.bouncycastle.asn1.cms.AttributeTable;
+import org.bouncycastle.asn1.cms.CMSAttributes;
+import org.bouncycastle.asn1.cms.Time;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.cert.jcajce.JcaCertStore;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.cms.CMSProcessableByteArray;
+import org.bouncycastle.cms.CMSSignedDataGenerator;
+import org.bouncycastle.cms.DefaultSignedAttributeTableGenerator;
+import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Generates a throwaway "Apple-like" RSA PKI (root, WWDR intermediate, receipt
+ * signing leaf) and CMS-signs synthetic legacy app receipts with it, so
+ * {@link com.apple.itunes.storekit.verification.AppReceiptVerifier} can be
+ * exercised without any real Apple key material or a checked-in receipt.
+ */
+public class ReceiptCreator {
+
+    private static final String WWDR_INTERMEDIATE_OID = "1.2.840.113635.100.6.2.1";
+    private static final String RECEIPT_SIGNER_OID = "1.2.840.113635.100.6.11.1";
+    private static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
+    private static final long DAY_IN_MILLIS = 86_400_000L;
+    private static final AtomicLong SERIAL = new AtomicLong(1);
+    private static final BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
+
+    /** Leaf first, then intermediate, then root; a self-signed creator holds one entry. */
+    private final List<X509Certificate> chain;
+    private final PrivateKey signingKey;
+
+    private ReceiptCreator(List<X509Certificate> chain, PrivateKey signingKey) {
+        this.chain = chain;
+        this.signingKey = signingKey;
+    }
+
+    /**
+     * A chain carrying both Apple marker OIDs, with a validity window wide
+     * enough to cover any plausible receipt creation date — the chain of a
+     * receipt is evaluated at the date the receipt was created, not now.
+     */
+    public static ReceiptCreator createReceiptCreator() throws Exception {
+        return createReceiptCreator(true, true, tenYearsAgo(), inOneYear());
+    }
+
+    /**
+     * @param receiptSignerOid Whether the leaf carries the receipt-signing marker OID
+     * @param wwdrIntermediateOid Whether the intermediate carries the WWDR marker OID
+     * @param notBefore The start of the validity window of every certificate in the chain
+     * @param notAfter The end of the validity window of every certificate in the chain
+     */
+    public static ReceiptCreator createReceiptCreator(boolean receiptSignerOid, boolean wwdrIntermediateOid, Date notBefore, Date notAfter) throws Exception {
+        KeyPair rootKeyPair = rsaKeyPair();
+        KeyPair intermediateKeyPair = rsaKeyPair();
+        KeyPair leafKeyPair = rsaKeyPair();
+        X509Certificate root = certificate("CN=Test App Store Root CA", rootKeyPair.getPublic(), "CN=Test App Store Root CA", rootKeyPair.getPrivate(), true, null, notBefore, notAfter);
+        X509Certificate intermediate = certificate("CN=Test WWDR CA", intermediateKeyPair.getPublic(), "CN=Test App Store Root CA", rootKeyPair.getPrivate(), true, wwdrIntermediateOid ? WWDR_INTERMEDIATE_OID : null, notBefore, notAfter);
+        X509Certificate leaf = certificate("CN=Test Receipt Signing", leafKeyPair.getPublic(), "CN=Test WWDR CA", intermediateKeyPair.getPrivate(), false, receiptSignerOid ? RECEIPT_SIGNER_OID : null, notBefore, notAfter);
+        return new ReceiptCreator(List.of(leaf, intermediate, root), leafKeyPair.getPrivate());
+    }
+
+    /**
+     * A single self-signed certificate, as an Xcode-generated receipt carries;
+     * such a receipt is never chain verified.
+     */
+    public static ReceiptCreator createSelfSignedReceiptCreator() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        X509Certificate certificate = certificate("CN=Test Xcode Receipt Signing", keyPair.getPublic(), "CN=Test Xcode Receipt Signing", keyPair.getPrivate(), false, RECEIPT_SIGNER_OID, tenYearsAgo(), inOneYear());
+        return new ReceiptCreator(List.of(certificate), keyPair.getPrivate());
+    }
+
+    /** The root of this chain, in the form the verifier's constructor accepts. */
+    public InputStream getRootCertificate() throws CertificateEncodingException {
+        return new ByteArrayInputStream(chain.get(chain.size() - 1).getEncoded());
+    }
+
+    /** CMS-signs {@code payload} as encapsulated content, embedding the whole chain. */
+    public byte[] signReceipt(byte[] payload) throws Exception {
+        return signReceipt(payload, chain.size(), new Date());
+    }
+
+    /**
+     * @param embeddedCertificates How many certificates of the chain, starting at
+     *                             the leaf, to embed in the container
+     */
+    public byte[] signReceipt(byte[] payload, int embeddedCertificates) throws Exception {
+        return signReceipt(payload, embeddedCertificates, new Date());
+    }
+
+    /**
+     * @param signingTime The CMS signing time attribute, which must fall inside
+     *                    the signer certificate's validity window for the
+     *                    signature to verify — an old receipt signed by a since
+     *                    expired certificate needs its original signing time
+     */
+    public byte[] signReceipt(byte[] payload, Date signingTime) throws Exception {
+        return signReceipt(payload, chain.size(), signingTime);
+    }
+
+    private byte[] signReceipt(byte[] payload, int embeddedCertificates, Date signingTime) throws Exception {
+        ASN1EncodableVector signedAttributes = new ASN1EncodableVector();
+        signedAttributes.add(new Attribute(CMSAttributes.signingTime, new DERSet(new Time(signingTime))));
+        CMSSignedDataGenerator generator = new CMSSignedDataGenerator();
+        ContentSigner contentSigner = new JcaContentSignerBuilder(SIGNATURE_ALGORITHM).build(signingKey);
+        generator.addSignerInfoGenerator(new JcaSignerInfoGeneratorBuilder(new JcaDigestCalculatorProviderBuilder().setProvider(BOUNCY_CASTLE_PROVIDER).build())
+                .setSignedAttributeGenerator(new DefaultSignedAttributeTableGenerator(new AttributeTable(signedAttributes)))
+                .build(contentSigner, chain.get(0)));
+        generator.addCertificates(new JcaCertStore(chain.subList(0, embeddedCertificates)));
+        return generator.generate(new CMSProcessableByteArray(payload), true).getEncoded();
+    }
+
+    public static AttributeSet attributeSet() {
+        return new AttributeSet();
+    }
+
+    /** The extra OCTET STRING wrapper Xcode-generated receipts put around the payload. */
+    public static byte[] doubleWrap(byte[] payload) throws IOException {
+        return new DEROctetString(payload).getEncoded();
+    }
+
+    /**
+     * Builds a receipt attribute SET, the shape both the receipt payload and the
+     * value of an in-app purchase attribute take. Each attribute is
+     * {@code SEQUENCE { type INTEGER, version INTEGER, value OCTET STRING }}.
+     */
+    public static class AttributeSet {
+        private final ASN1EncodableVector attributes = new ASN1EncodableVector();
+
+        private AttributeSet() {
+        }
+
+        /** An attribute whose value is a DER UTF8String, e.g. the bundle identifier. */
+        public AttributeSet string(int type, String value) throws IOException {
+            return raw(type, new DERUTF8String(value).getEncoded());
+        }
+
+        /** An attribute whose value is a DER IA5String holding an RFC 3339 date. */
+        public AttributeSet date(int type, String value) throws IOException {
+            return raw(type, new DERIA5String(value).getEncoded());
+        }
+
+        /** An attribute whose value is a DER INTEGER, e.g. a purchase quantity. */
+        public AttributeSet integer(int type, long value) throws IOException {
+            return raw(type, new ASN1Integer(value).getEncoded());
+        }
+
+        /** An attribute whose value bytes are used as-is, e.g. an opaque value or a nested SET. */
+        public AttributeSet raw(int type, byte[] value) {
+            attributes.add(new DERSequence(new ASN1Encodable[]{new ASN1Integer(type), new ASN1Integer(1), new DEROctetString(value)}));
+            return this;
+        }
+
+        public byte[] build() throws IOException {
+            return new DERSet(attributes).getEncoded();
+        }
+    }
+
+    private static Date tenYearsAgo() {
+        return new Date(System.currentTimeMillis() - 3650 * DAY_IN_MILLIS);
+    }
+
+    private static Date inOneYear() {
+        return new Date(System.currentTimeMillis() + 365 * DAY_IN_MILLIS);
+    }
+
+    private static KeyPair rsaKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static X509Certificate certificate(String subject, PublicKey subjectKey, String issuer, PrivateKey issuerKey, boolean certificateAuthority, String markerOid, Date notBefore, Date notAfter) throws Exception {
+        JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(new X500Name(issuer), BigInteger.valueOf(SERIAL.getAndIncrement()), notBefore, notAfter, new X500Name(subject), subjectKey);
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(certificateAuthority));
+        if (markerOid != null) {
+            // The Apple marker extensions are non-critical and carry no value
+            builder.addExtension(new ASN1ObjectIdentifier(markerOid), false, DERNull.INSTANCE);
+        }
+        ContentSigner contentSigner = new JcaContentSignerBuilder(SIGNATURE_ALGORITHM).build(issuerKey);
+        return new JcaX509CertificateConverter().getCertificate(builder.build(contentSigner));
+    }
+}

--- a/src/test/java/com/apple/itunes/storekit/verification/AppReceiptVerifierTest.java
+++ b/src/test/java/com/apple/itunes/storekit/verification/AppReceiptVerifierTest.java
@@ -1,0 +1,416 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+package com.apple.itunes.storekit.verification;
+
+import com.apple.itunes.storekit.model.AppReceipt;
+import com.apple.itunes.storekit.model.Environment;
+import com.apple.itunes.storekit.model.InAppPurchaseReceipt;
+import com.apple.itunes.storekit.util.ReceiptCreator;
+import org.bouncycastle.asn1.DERUTF8String;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertPathValidatorException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Set;
+
+public class AppReceiptVerifierTest {
+
+    private static final String BUNDLE_ID = "com.example";
+    private static final String APP_VERSION = "1.2.3";
+    private static final String ORIGINAL_APP_VERSION = "1.0";
+    private static final byte[] OPAQUE_VALUE = {1, 2, 3, 4, 5, 6, 7, 8};
+    private static final byte[] SHA1_HASH = {
+            (byte) 0xa1, (byte) 0xb2, (byte) 0xc3, (byte) 0xd4, (byte) 0xe5, (byte) 0xf6, 0x07, 0x18,
+            0x29, 0x3a, 0x4b, 0x5c, 0x6d, 0x7e, (byte) 0x8f, (byte) 0x90, 0x11, 0x22, 0x33, 0x44};
+    private static final byte[] UNKNOWN_RECEIPT_ATTRIBUTE_VALUE = {0x0d, 0x0e, 0x0a, 0x0d};
+    private static final byte[] UNKNOWN_IN_APP_ATTRIBUTE_VALUE = {0x0b, 0x0e, 0x0e, 0x0f};
+
+    private static final String RECEIPT_CREATION_DATE = "2024-03-01T12:00:00Z";
+    private static final long RECEIPT_CREATION_DATE_MILLIS = 1709294400000L;
+    private static final String ORIGINAL_PURCHASE_DATE = "2023-11-15T08:30:00Z";
+    private static final long ORIGINAL_PURCHASE_DATE_MILLIS = 1700037000000L;
+    private static final String EXPIRATION_DATE = "2030-01-01T00:00:00Z";
+    private static final long EXPIRATION_DATE_MILLIS = 1893456000000L;
+
+    private static final String CONSUMABLE_PRODUCT_ID = "com.example.coins";
+    private static final String CONSUMABLE_PURCHASE_DATE = "2024-01-15T12:00:00Z";
+    private static final long CONSUMABLE_PURCHASE_DATE_MILLIS = 1705320000000L;
+    private static final String CONSUMABLE_ORIGINAL_PURCHASE_DATE = "2024-01-10T09:00:00Z";
+    private static final long CONSUMABLE_ORIGINAL_PURCHASE_DATE_MILLIS = 1704877200000L;
+
+    private static final String SUBSCRIPTION_PRODUCT_ID = "com.example.subscription";
+    private static final String SUBSCRIPTION_PURCHASE_DATE = "2024-02-01T09:30:00Z";
+    private static final long SUBSCRIPTION_PURCHASE_DATE_MILLIS = 1706779800000L;
+    private static final String SUBSCRIPTION_EXPIRES_DATE = "2030-02-01T09:30:00Z";
+    private static final long SUBSCRIPTION_EXPIRES_DATE_MILLIS = 1896168600000L;
+    private static final String SUBSCRIPTION_CANCELLATION_DATE = "2024-06-01T00:00:00Z";
+    private static final long SUBSCRIPTION_CANCELLATION_DATE_MILLIS = 1717200000000L;
+
+    private static final long DAY_IN_MILLIS = 86_400_000L;
+
+    private static ReceiptCreator receiptCreator;
+    private static byte[] sandboxReceipt;
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        receiptCreator = ReceiptCreator.createReceiptCreator();
+        sandboxReceipt = receiptCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE));
+    }
+
+    @Test
+    public void testAppReceiptDecoding() throws Exception {
+        AppReceipt receipt = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(sandboxReceipt));
+
+        Assertions.assertEquals("ProductionSandbox", receipt.getReceiptType());
+        Assertions.assertEquals(BUNDLE_ID, receipt.getBundleId());
+        Assertions.assertArrayEquals(new DERUTF8String(BUNDLE_ID).getEncoded(), receipt.getBundleIdBytes());
+        Assertions.assertEquals(APP_VERSION, receipt.getApplicationVersion());
+        Assertions.assertEquals(ORIGINAL_APP_VERSION, receipt.getOriginalApplicationVersion());
+        Assertions.assertArrayEquals(OPAQUE_VALUE, receipt.getOpaqueValue());
+        Assertions.assertArrayEquals(SHA1_HASH, receipt.getSha1Hash());
+        Assertions.assertEquals(RECEIPT_CREATION_DATE_MILLIS, receipt.getReceiptCreationDate());
+        Assertions.assertEquals(ORIGINAL_PURCHASE_DATE_MILLIS, receipt.getOriginalPurchaseDate());
+        Assertions.assertEquals(EXPIRATION_DATE_MILLIS, receipt.getExpirationDate());
+        Assertions.assertEquals(2, receipt.getInAppPurchases().size());
+
+        InAppPurchaseReceipt consumable = receipt.getInAppPurchases().get(0);
+        Assertions.assertEquals(1L, consumable.getQuantity());
+        Assertions.assertEquals(CONSUMABLE_PRODUCT_ID, consumable.getProductId());
+        Assertions.assertEquals("70000000000001", consumable.getTransactionId());
+        Assertions.assertEquals("70000000000001", consumable.getOriginalTransactionId());
+        Assertions.assertEquals(CONSUMABLE_PURCHASE_DATE_MILLIS, consumable.getPurchaseDate());
+        Assertions.assertEquals(CONSUMABLE_ORIGINAL_PURCHASE_DATE_MILLIS, consumable.getOriginalPurchaseDate());
+        Assertions.assertEquals(42L, consumable.getWebOrderLineItemId());
+
+        InAppPurchaseReceipt subscription = receipt.getInAppPurchases().get(1);
+        Assertions.assertEquals(1L, subscription.getQuantity());
+        Assertions.assertEquals(SUBSCRIPTION_PRODUCT_ID, subscription.getProductId());
+        Assertions.assertEquals("70000000000002", subscription.getTransactionId());
+        Assertions.assertEquals("70000000000002", subscription.getOriginalTransactionId());
+        Assertions.assertEquals(SUBSCRIPTION_PURCHASE_DATE_MILLIS, subscription.getPurchaseDate());
+        Assertions.assertEquals(SUBSCRIPTION_PURCHASE_DATE_MILLIS, subscription.getOriginalPurchaseDate());
+        Assertions.assertEquals(SUBSCRIPTION_EXPIRES_DATE_MILLIS, subscription.getExpiresDate());
+        Assertions.assertEquals(SUBSCRIPTION_CANCELLATION_DATE_MILLIS, subscription.getCancellationDate());
+        Assertions.assertEquals(12345L, subscription.getWebOrderLineItemId());
+    }
+
+    /**
+     * An in-app purchase attribute that is present but empty means "absent", and
+     * the intro offer flag is an integer that must surface as a boolean, so a
+     * caller can distinguish "no expiration" from "expired at epoch".
+     */
+    @Test
+    public void testInAppPurchaseFlagAndEmptyDateDecoding() throws Exception {
+        AppReceipt receipt = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(sandboxReceipt));
+
+        InAppPurchaseReceipt consumable = receipt.getInAppPurchases().get(0);
+        Assertions.assertEquals(Boolean.FALSE, consumable.getIsInIntroOfferPeriod());
+        Assertions.assertNull(consumable.getExpiresDate());
+        Assertions.assertNull(consumable.getCancellationDate());
+
+        InAppPurchaseReceipt subscription = receipt.getInAppPurchases().get(1);
+        Assertions.assertEquals(Boolean.TRUE, subscription.getIsInIntroOfferPeriod());
+    }
+
+    /**
+     * Attribute types this library does not model must survive decoding with
+     * their raw bytes, so a receipt field Apple adds later stays reachable.
+     */
+    @Test
+    public void testUnknownAttributesArePreserved() throws Exception {
+        AppReceipt receipt = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(sandboxReceipt));
+
+        Assertions.assertEquals(1, receipt.getUnknownAttributes().get(9999).size());
+        Assertions.assertArrayEquals(UNKNOWN_RECEIPT_ATTRIBUTE_VALUE, receipt.getUnknownAttributes().get(9999).get(0));
+        Assertions.assertArrayEquals(UNKNOWN_IN_APP_ATTRIBUTE_VALUE, receipt.getInAppPurchases().get(0).getUnknownAttributes().get(1799).get(0));
+    }
+
+    @Test
+    public void testWrongBundleId() throws Exception {
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, "com.example.other", false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(sandboxReceipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_APP_IDENTIFIER, exception.getStatus());
+    }
+
+    @Test
+    public void testWrongEnvironment() throws Exception {
+        byte[] productionReceipt = receiptCreator.signReceipt(receiptPayload("Production", BUNDLE_ID, RECEIPT_CREATION_DATE));
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(productionReceipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_ENVIRONMENT, exception.getStatus());
+    }
+
+    /**
+     * A receipt type this library does not recognize maps to no environment at
+     * all rather than defaulting to the verifier's, so an unexpected value can
+     * never be mistaken for a match.
+     */
+    @Test
+    public void testUnknownReceiptType() throws Exception {
+        byte[] unknownTypeReceipt = receiptCreator.signReceipt(receiptPayload("ProductionInternal", BUNDLE_ID, RECEIPT_CREATION_DATE));
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(unknownTypeReceipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_ENVIRONMENT, exception.getStatus());
+    }
+
+    @Test
+    public void testTamperedPayload() throws Exception {
+        byte[] tamperedReceipt = sandboxReceipt.clone();
+        // Flip a bit inside the app version of the encapsulated payload; the
+        // chain is untouched, so only the signature check can catch this.
+        tamperedReceipt[indexOf(tamperedReceipt, APP_VERSION.getBytes(StandardCharsets.UTF_8))] ^= 0x01;
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(tamperedReceipt)));
+        Assertions.assertEquals(VerificationStatus.VERIFICATION_FAILURE, exception.getStatus());
+    }
+
+    @Test
+    public void testReceiptSignedByForeignRoot() throws Exception {
+        ReceiptCreator foreignCreator = ReceiptCreator.createReceiptCreator();
+        byte[] forgedReceipt = foreignCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE));
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(forgedReceipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_CHAIN, exception.getStatus());
+    }
+
+    @Test
+    public void testLeafWithoutReceiptSigningOid() throws Exception {
+        ReceiptCreator creator = ReceiptCreator.createReceiptCreator(false, true, daysAgo(3650), inOneYear());
+        byte[] receipt = creator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE));
+        AppReceiptVerifier verifier = getReceiptVerifier(creator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_CHAIN, exception.getStatus());
+        Assertions.assertInstanceOf(CertPathValidatorException.class, exception.getCause());
+        Assertions.assertTrue(exception.getCause().toString().contains("OID: 1.2.840.113635.100.6.11.1 was not found on the signing certificate"));
+    }
+
+    @Test
+    public void testIntermediateWithoutWwdrOid() throws Exception {
+        ReceiptCreator creator = ReceiptCreator.createReceiptCreator(true, false, daysAgo(3650), inOneYear());
+        byte[] receipt = creator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE));
+        AppReceiptVerifier verifier = getReceiptVerifier(creator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_CHAIN, exception.getStatus());
+        Assertions.assertInstanceOf(CertPathValidatorException.class, exception.getCause());
+        Assertions.assertTrue(exception.getCause().toString().contains("OID: 1.2.840.113635.100.6.2.1 was not found on the intermediate WWDR certificate"));
+    }
+
+    @Test
+    public void testReceiptWithoutRootCertificateEmbedded() throws Exception {
+        byte[] receipt = receiptCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), 2);
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_CHAIN_LENGTH, exception.getStatus());
+    }
+
+    @Test
+    public void testReceiptThatIsNotBase64() throws Exception {
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt("!!!not-base64!!!"));
+        Assertions.assertEquals(VerificationStatus.VERIFICATION_FAILURE, exception.getStatus());
+    }
+
+    @Test
+    public void testReceiptThatIsNotAPkcs7Container() throws Exception {
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(new byte[]{1, 2, 3, 4})));
+        Assertions.assertEquals(VerificationStatus.VERIFICATION_FAILURE, exception.getStatus());
+    }
+
+    /**
+     * Bytes appended after the container must not be ignored — a verifier that
+     * parsed a prefix would accept a receipt carrying unverified extra data.
+     */
+    @Test
+    public void testTrailingBytesAfterContainer() throws Exception {
+        byte[] paddedReceipt = new byte[sandboxReceipt.length + 4];
+        System.arraycopy(sandboxReceipt, 0, paddedReceipt, 0, sandboxReceipt.length);
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(paddedReceipt)));
+        Assertions.assertEquals(VerificationStatus.VERIFICATION_FAILURE, exception.getStatus());
+    }
+
+    /**
+     * Receipts outlive the certificates that signed them, so with online checks
+     * off the chain is evaluated at the receipt's creation date.
+     */
+    @Test
+    public void testReceiptSignedByNowExpiredCertificates() throws Exception {
+        ReceiptCreator expiredCreator = ReceiptCreator.createReceiptCreator(true, true, daysAgo(730), daysAgo(365));
+        Instant createdAt = Instant.now().minus(547, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+        String creationDate = createdAt.toString();
+        byte[] receipt = expiredCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, creationDate), Date.from(createdAt));
+
+        AppReceipt decoded = getReceiptVerifier(expiredCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(receipt));
+        Assertions.assertEquals(Instant.parse(creationDate).toEpochMilli(), decoded.getReceiptCreationDate());
+    }
+
+    /**
+     * Enabling online checks moves the evaluation to now, which is the point of
+     * the option: the same receipt must then fail on the expired chain.
+     */
+    @Test
+    public void testReceiptSignedByNowExpiredCertificatesWithOnlineChecks() throws Exception {
+        ReceiptCreator expiredCreator = ReceiptCreator.createReceiptCreator(true, true, daysAgo(730), daysAgo(365));
+        Instant createdAt = Instant.now().minus(547, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+        String creationDate = createdAt.toString();
+        byte[] receipt = expiredCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, creationDate), Date.from(createdAt));
+
+        AppReceiptVerifier verifier = getReceiptVerifier(expiredCreator, Environment.SANDBOX, BUNDLE_ID, true);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_CHAIN, exception.getStatus());
+    }
+
+    /**
+     * Xcode-generated receipts are not signed by the App Store, so they are
+     * decoded without any chain or signature check.
+     */
+    @Test
+    public void testXcodeReceiptDecoding() throws Exception {
+        ReceiptCreator xcodeCreator = ReceiptCreator.createSelfSignedReceiptCreator();
+        byte[] receipt = xcodeCreator.signReceipt(ReceiptCreator.doubleWrap(receiptPayload("Xcode", BUNDLE_ID, RECEIPT_CREATION_DATE)));
+
+        AppReceipt decoded = getReceiptVerifier(xcodeCreator, Environment.XCODE, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(receipt));
+        Assertions.assertEquals("Xcode", decoded.getReceiptType());
+        Assertions.assertEquals(BUNDLE_ID, decoded.getBundleId());
+        Assertions.assertEquals(APP_VERSION, decoded.getApplicationVersion());
+        Assertions.assertEquals(RECEIPT_CREATION_DATE_MILLIS, decoded.getReceiptCreationDate());
+        Assertions.assertEquals(2, decoded.getInAppPurchases().size());
+    }
+
+    /** Skipping the signature checks must not skip the app identity check. */
+    @Test
+    public void testXcodeReceiptWithWrongBundleId() throws Exception {
+        ReceiptCreator xcodeCreator = ReceiptCreator.createSelfSignedReceiptCreator();
+        byte[] receipt = xcodeCreator.signReceipt(ReceiptCreator.doubleWrap(receiptPayload("Xcode", BUNDLE_ID, RECEIPT_CREATION_DATE)));
+
+        AppReceiptVerifier verifier = getReceiptVerifier(xcodeCreator, Environment.XCODE, "com.example.other", false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_APP_IDENTIFIER, exception.getStatus());
+    }
+
+    /** Skipping the signature checks must not skip the environment check either. */
+    @Test
+    public void testXcodeReceiptWithWrongEnvironment() throws Exception {
+        ReceiptCreator xcodeCreator = ReceiptCreator.createSelfSignedReceiptCreator();
+        byte[] receipt = xcodeCreator.signReceipt(ReceiptCreator.doubleWrap(receiptPayload("Production", BUNDLE_ID, RECEIPT_CREATION_DATE)));
+
+        AppReceiptVerifier verifier = getReceiptVerifier(xcodeCreator, Environment.XCODE, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_ENVIRONMENT, exception.getStatus());
+    }
+
+    @Test
+    public void testVerifyAndExtractTransactionId() throws Exception {
+        String transactionId = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndExtractTransactionId(encode(sandboxReceipt));
+        Assertions.assertEquals("70000000000001", transactionId);
+    }
+
+    /** Same output contract as ReceiptUtility: a verified receipt with no in-app purchases yields null. */
+    @Test
+    public void testVerifyAndExtractTransactionIdWithoutInAppPurchases() throws Exception {
+        byte[] receipt = receiptCreator.signReceipt(ReceiptCreator.attributeSet()
+                .string(0, "ProductionSandbox")
+                .string(2, BUNDLE_ID)
+                .date(12, RECEIPT_CREATION_DATE)
+                .build());
+        Assertions.assertNull(getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndExtractTransactionId(encode(receipt)));
+    }
+
+    /** Unlike ReceiptUtility, extraction refuses a receipt that does not verify. */
+    @Test
+    public void testVerifyAndExtractTransactionIdRejectsForeignReceipt() throws Exception {
+        ReceiptCreator foreignCreator = ReceiptCreator.createReceiptCreator();
+        byte[] receipt = foreignCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE));
+
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndExtractTransactionId(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_CHAIN, exception.getStatus());
+    }
+
+    private static AppReceiptVerifier getReceiptVerifier(ReceiptCreator creator, Environment environment, String bundleId, boolean enableOnlineChecks) throws Exception {
+        return new AppReceiptVerifier(Set.of(creator.getRootCertificate()), bundleId, environment, enableOnlineChecks);
+    }
+
+    private static byte[] receiptPayload(String receiptType, String bundleId, String creationDate) throws Exception {
+        return ReceiptCreator.attributeSet()
+                .string(0, receiptType)
+                .string(2, bundleId)
+                .string(3, APP_VERSION)
+                .raw(4, OPAQUE_VALUE)
+                .raw(5, SHA1_HASH)
+                .date(12, creationDate)
+                .date(18, ORIGINAL_PURCHASE_DATE)
+                .string(19, ORIGINAL_APP_VERSION)
+                .date(21, EXPIRATION_DATE)
+                .raw(9999, UNKNOWN_RECEIPT_ATTRIBUTE_VALUE)
+                .raw(17, consumablePurchase())
+                .raw(17, subscriptionPurchase())
+                .build();
+    }
+
+    private static byte[] consumablePurchase() throws Exception {
+        return ReceiptCreator.attributeSet()
+                .integer(1701, 1)
+                .string(1702, CONSUMABLE_PRODUCT_ID)
+                .string(1703, "70000000000001")
+                .date(1704, CONSUMABLE_PURCHASE_DATE)
+                .string(1705, "70000000000001")
+                .date(1706, CONSUMABLE_ORIGINAL_PURCHASE_DATE)
+                .date(1708, "")
+                .integer(1711, 42)
+                .date(1712, "")
+                .integer(1719, 0)
+                .raw(1799, UNKNOWN_IN_APP_ATTRIBUTE_VALUE)
+                .build();
+    }
+
+    private static byte[] subscriptionPurchase() throws Exception {
+        return ReceiptCreator.attributeSet()
+                .integer(1701, 1)
+                .string(1702, SUBSCRIPTION_PRODUCT_ID)
+                .string(1703, "70000000000002")
+                .date(1704, SUBSCRIPTION_PURCHASE_DATE)
+                .string(1705, "70000000000002")
+                .date(1706, SUBSCRIPTION_PURCHASE_DATE)
+                .date(1708, SUBSCRIPTION_EXPIRES_DATE)
+                .integer(1711, 12345)
+                .date(1712, SUBSCRIPTION_CANCELLATION_DATE)
+                .integer(1719, 1)
+                .build();
+    }
+
+    private static String encode(byte[] receipt) {
+        return Base64.getEncoder().encodeToString(receipt);
+    }
+
+    private static Date inOneYear() {
+        return new Date(System.currentTimeMillis() + 365 * DAY_IN_MILLIS);
+    }
+
+    private static Date daysAgo(int days) {
+        return new Date(System.currentTimeMillis() - days * DAY_IN_MILLIS);
+    }
+
+    private static int indexOf(byte[] haystack, byte[] needle) {
+        for (int i = 0; i <= haystack.length - needle.length; i++) {
+            boolean match = true;
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) {
+                return i;
+            }
+        }
+        throw new AssertionError("Expected bytes not found in the receipt");
+    }
+}

--- a/src/test/java/com/apple/itunes/storekit/verification/AppReceiptVerifierTest.java
+++ b/src/test/java/com/apple/itunes/storekit/verification/AppReceiptVerifierTest.java
@@ -306,6 +306,84 @@ public class AppReceiptVerifierTest {
         Assertions.assertEquals(VerificationStatus.INVALID_ENVIRONMENT, exception.getStatus());
     }
 
+    /**
+     * The signer certificate is what the chain is built for, so a receipt whose
+     * signer is not among the embedded certificates has no chain to verify.
+     */
+    @Test
+    public void testReceiptWithoutTheSignerCertificateEmbedded() throws Exception {
+        byte[] receipt = receiptCreator.signReceiptWithoutSignerCertificate(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE));
+
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_CHAIN, exception.getStatus());
+    }
+
+    /**
+     * The embedded certificates are attacker-supplied and are ordered into a
+     * chain before anything about the receipt has been verified, so a receipt
+     * carrying more of them than a chain can hold is rejected rather than
+     * assembled.
+     */
+    @Test
+    public void testReceiptWithTooManyEmbeddedCertificates() throws Exception {
+        byte[] receipt = receiptCreator.signReceiptWithPadding(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), 30);
+
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_CHAIN_LENGTH, exception.getStatus());
+    }
+
+    /**
+     * A correctly signed receipt still fails when the signer names a digest
+     * outside the allowlist, so the accepted algorithms never widen to whatever
+     * a signer proposes.
+     */
+    @Test
+    public void testReceiptWithADigestAppleDoesNotUse() throws Exception {
+        byte[] receipt = receiptCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE), "SHA512withRSA");
+
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.VERIFICATION_FAILURE, exception.getStatus());
+    }
+
+    /**
+     * The payload is parsed before it has been verified, so a date it can carry
+     * but no instant can represent must surface as a verification failure rather
+     * than as a runtime exception escaping the declared contract.
+     */
+    @Test
+    public void testReceiptWithADateOutsideTheRepresentableRange() throws Exception {
+        byte[] receipt = receiptCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, "+1000000000-01-01T00:00:00Z"));
+
+        AppReceiptVerifier verifier = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.VERIFICATION_FAILURE, exception.getStatus());
+    }
+
+    /** As with an Xcode receipt, LocalTesting data is not signed by the App Store. */
+    @Test
+    public void testLocalTestingReceiptDecoding() throws Exception {
+        ReceiptCreator localTestingCreator = ReceiptCreator.createSelfSignedReceiptCreator();
+        byte[] receipt = localTestingCreator.signReceipt(receiptPayload("LocalTesting", BUNDLE_ID, RECEIPT_CREATION_DATE));
+
+        AppReceipt decoded = getReceiptVerifier(localTestingCreator, Environment.LOCAL_TESTING, BUNDLE_ID, false).verifyAndDecodeAppReceipt(encode(receipt));
+        Assertions.assertEquals("LocalTesting", decoded.getReceiptType());
+        Assertions.assertEquals(BUNDLE_ID, decoded.getBundleId());
+    }
+
+    /** Skipping the signature checks must not skip the app identity check. */
+    @Test
+    public void testLocalTestingReceiptWithWrongBundleId() throws Exception {
+        ReceiptCreator localTestingCreator = ReceiptCreator.createSelfSignedReceiptCreator();
+        byte[] receipt = localTestingCreator.signReceipt(receiptPayload("LocalTesting", BUNDLE_ID, RECEIPT_CREATION_DATE));
+
+        AppReceiptVerifier verifier = getReceiptVerifier(localTestingCreator, Environment.LOCAL_TESTING, "com.example.other", false);
+        VerificationException exception = Assertions.assertThrows(VerificationException.class, () -> verifier.verifyAndDecodeAppReceipt(encode(receipt)));
+        Assertions.assertEquals(VerificationStatus.INVALID_APP_IDENTIFIER, exception.getStatus());
+    }
+
     @Test
     public void testVerifyAndExtractTransactionId() throws Exception {
         String transactionId = getReceiptVerifier(receiptCreator, Environment.SANDBOX, BUNDLE_ID, false).verifyAndExtractTransactionId(encode(sandboxReceipt));


### PR DESCRIPTION
Resolves #267, which also lists prior issues across the four libraries asking for exactly this (apple/app-store-server-library-node#172, apple/app-store-server-library-swift#66, apple/app-store-server-library-python#55). The same change is now open for the other three libraries as well: apple/app-store-server-library-swift#133, apple/app-store-server-library-python#208, apple/app-store-server-library-node#427.

Adds `AppReceiptVerifier`, the validating counterpart to `ReceiptUtility`: it verifies the PKCS#7 app receipt's certificate chain and signature, then decodes the receipt and its in-app purchase attributes. For apps that still support iOS 14 and earlier, where StoreKit 2 isn't available, the app receipt is the only purchase artifact there is — and today the library extracts a transaction ID from it without checking that the App Store ever signed it.

Design notes:

- **Maximum reuse of the existing trust code.** The embedded certificates are ordered leaf → intermediate → root and handed to the existing `ChainVerifier`, which already enforces the chain length, the WWDR intermediate OID (1.2.840.113635.100.6.2.1) and the receipt-signing leaf OID (1.2.840.113635.100.6.11.1) via `AppleExtensionCertPathChecker`, against the same caller-supplied Apple root certificates `SignedDataVerifier` takes. No new trust logic.
- **Chain validity is evaluated at the receipt's creation date** (via `ChainVerifier`'s existing `effectiveDate` parameter), so old receipts survive certificate rotations — in line with [Apple's Dec 2022 signing-certificate notice](https://developer.apple.com/news/?id=ytb7qj0x). `enableOnlineChecks` moves evaluation to the current date and enables revocation checking, matching `SignedDataVerifier`'s semantics.
- **No API surface beyond the new classes.** Errors map onto the existing `VerificationStatus` values; no enum additions. In the Xcode and LocalTesting environments the signature checks are skipped but the bundle id and environment are still validated, mirroring `SignedDataVerifier`.
- **Models** `AppReceipt` and `InAppPurchaseReceipt` follow the existing fluent-setter style. Attribute types the library doesn't model are preserved as raw bytes, so fields Apple adds later stay reachable without a library update.
- **`verifyAndExtractTransactionId`** has `extractTransactionIdFromAppReceipt`'s exact output contract, but only after verification; `ReceiptUtility`'s javadoc now cross-references it (doc-only touch there).
- **`bcpkix-jdk18on` (same vendor and version as the existing `bcprov` dependency) is added** for CMS signature verification.

**Adversarial review pass.** After opening this, I had the branch reviewed adversarially (independent per-language passes, each running its own probes). No verification bypass was found in any language — signature-to-payload binding, chain-to-signing-key binding, the digest allowlist, the RFC 5652 re-tag and trailing-byte rejection were each positively verified rather than assumed. What the review did find, and what a later commit here fixes, was denial of service: work reachable *before* anything about a receipt has been verified, needing no Apple key material. Ordering the embedded certificates into a chain compared them by DER equality, so 4000 embedded certificates measured at 36 seconds of one core; and a date attribute carrying an unrepresentable year escaped as an `ArithmeticException` past the declared `VerificationException` contract, which `SignedDataVerifier`'s catch-all would have contained. Those bounds sit before the expensive step. A later pass then put a test behind each pre-verification bound and each receipt shape the verifier claims to handle — tests that fail when their bound is removed or widened by one, found by running mutations over the previous suite rather than by assuming the earlier tests covered them.

Tests generate a throwaway in-memory PKI (`ReceiptCreator`, in the style of `SignedDataCreator`) and CMS-sign synthetic receipts — no real receipts or Apple key material. `AppReceiptVerifierTest` holds 41 tests covering decoding, tampering, foreign roots, missing marker OIDs, chain length, trailing bytes, expired-chain-at-creation-date behavior (with and without online checks), Xcode receipts, receipts signed without signed attributes (the shape every real App Store receipt has), the pre-verification bounds, and the extraction contract. The full suite passes (208 tests).

The same design is shipped and cross-verified in all four library languages in [apple-purchase-receipt-verifier](https://github.com/emindeniz99/apple-purchase-receipt-verifier) (MIT), against a shared fixture suite — this PR is that implementation rewritten in this library's idiom, reusing its existing trust code instead of carrying its own.

Happy to adjust naming or shape to whatever fits the library best.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>






