### PR TITLE
Fix null request bodies for PUT requests

### DIFF
--- a/src/main/java/com/apple/itunes/storekit/client/BaseAppStoreServerAPIClient.java
+++ b/src/main/java/com/apple/itunes/storekit/client/BaseAppStoreServerAPIClient.java
@@ -125,7 +125,7 @@ public abstract class BaseAppStoreServerAPIClient {
             encodedBody = (byte[]) body;
         } else if (body != null) {
             encodedBody = objectMapper.writeValueAsString(body).getBytes(StandardCharsets.UTF_8);
-        } else if (method.equals("POST")) {
+        } else if (method.equals("POST") || method.equals("PUT")) {
             encodedBody = new byte[] {};
         } else {
             encodedBody = null;

--- a/src/test/java/com/apple/itunes/storekit/client/AppStoreServerAPIClientTest.java
+++ b/src/test/java/com/apple/itunes/storekit/client/AppStoreServerAPIClientTest.java
@@ -791,6 +791,24 @@ public class AppStoreServerAPIClientTest {
     }
 
     @Test
+    public void testConfigureRealtimeURLWithNullBody() throws IOException, APIException {
+        AppStoreServerAPIClient client = getAppStoreServerAPIClient("", request -> {
+            Assertions.assertEquals("PUT", request.method());
+            Assertions.assertEquals("/inApps/v1/messaging/realtime/url", request.url().encodedPath());
+            RequestBody body = request.body();
+            Assertions.assertNotNull(body);
+            Assertions.assertEquals(expectedMediaType, body.contentType());
+            try {
+                Assertions.assertEquals(0, body.contentLength());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        client.configureRealtimeURL(null);
+    }
+
+    @Test
     public void testDeleteRealtimeURL() throws IOException, APIException {
         AppStoreServerAPIClient client = getAppStoreServerAPIClient("", request -> {
             Assertions.assertEquals("DELETE", request.method());


### PR DESCRIPTION
 ## Summary
                                                                                                                                                                                                                                    
  Fixes null request bodies for `PUT` requests by sending an empty request body instead of passing `null` to OkHttp.                                                                                                                
                                                                                                                                                                                                                                    
  ## Problem                                                                                                                                                                                                                        
                                                                                                                                                                                                                                    
  While reading through the request-building code, I noticed that `POST` requests with a null body were already converted to an empty byte array before building the OkHttp request. However, `PUT` requests were not handled the   
  same way.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                    
  When a `PUT` endpoint is called with a null request object, the client can call:                                                                                                                                                  
                                                                                                                                                                                                                                    
  ```java                                                                                                                                                                                                                           
  requestBuilder.method("PUT", null)                                                                                                                                                                                                
```                                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                    
  ## Expected Behavior                                                                                                                                                                                                              
                                                                                                                                                                                                                                    
  The client should build a valid PUT request with a zero-length request body, matching the existing behavior for null-body POST requests.                                                                                          
                                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                                        
                                                                                                                                                                                                                                    
  - Converts null bodies for POST and PUT requests into an empty byte array.                                                                                                                                                        
  - Adds test coverage for a null-body PUT request.
